### PR TITLE
feat: support OpenCode v2 alongside v1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,17 +19,58 @@ OpenCode plugin that tracks AI token throughput in real-time. Displays TPS stati
 ```
 ./
 ├── src/
-│   ├── index.ts          # Plugin entry point - event handlers
-│   ├── types.ts          # All TypeScript interfaces
-│   ├── tracker.ts        # TPS calculation logic (ring buffer)
-│   ├── ui.ts             # Display/throttling manager
-│   ├── tokenCounter.ts   # Heuristic token counting
-│   ├── config.ts         # Config loading (env + JSON files)
-│   └── __tests__/        # Integration + E2E tests
-├── build.ts              # Bun build script (dual format)
-├── package.json          # ESM/CJS dual exports
+│   ├── index.ts          # dual-host module: { id, server (v1), setup (v2) }
+│   ├── tui.tsx           # dual-host TUI module: { id, tui (v1), setup (v2) }
+│   ├── types.ts          # v1 TypeScript interfaces
+│   ├── tracker.ts        # TPS calculation logic (ring buffer) - shared v1/v2
+│   ├── tokenCounter.ts   # Heuristic token counting - shared v1/v2
+│   ├── config.ts         # Config loading (env + JSON + v2 inline options) - shared
+│   ├── constants.ts      # Shared constants
+│   ├── format.ts         # Shared meter text formatting (v1 + v2 render identically)
+│   ├── ui.ts             # v1 toast/throttling manager (no v2 equivalent)
+│   ├── v2/
+│   │   ├── types.ts      # Structural v2 API types (events, contexts, slots, storage)
+│   │   ├── dispatch.ts   # routes v2 setup() to TUI or server by context shape
+│   │   ├── meter.ts      # v2 session tracking core - drives both v2 entries
+│   │   ├── metrics.ts    # calibration + turn decomposition (TTFT, tool time)
+│   │   ├── ledger.ts     # durable per-model rollup via ctx.storage.store
+│   │   ├── server.ts     # v2 server entry (no UI; wire-level TTFB hooks)
+│   │   └── tui.tsx       # v2 TUI entry: footer meter, sidebar panel, dashboard
+│   └── __tests__/        # Integration + E2E + v2 tests
+├── build.ts              # Bun build script (dual format, 4 entrypoints)
+├── package.json          # ESM/CJS dual exports + /v2 subpaths
 └── tsconfig.json         # Strict TypeScript config
 ```
+
+**v2 loader constraints (verified against `opencode2` beta 17639 — do not regress):**
+1. The default export MUST be an object. v2 validates it against an Effect schema and rejects a
+   callable with `SchemaError(Expected object at ["default"])`. The old v1 bare-function style
+   cannot load on v2. v1 accepts both a bare function and `{ id, server }`, so the object form is
+   the only shape that works on both.
+2. Entries in v2's `plugins` array are npm package names or local paths — NOT subpaths.
+   `"opencode-tps-meter/v2"` is attempted as a package install and fails. The `/v2` exports are
+   for programmatic `import` only.
+3. **v2 DOES implement the TUI plugin API** — verified in the shipped `opencode2` beta binary, not
+   from the repo. Its own built-in TUI plugins use exactly this package's target API:
+   `Plugin.define({ id, setup })`, `ctx.ui.slot({ append: "app", render })`, `ctx.data.on(type, fn)`,
+   and a returned cleanup function (see `opencode.notifications`, `diff-viewer`).
+   CAUTION when researching this: the GitHub `dev` branch has DIVERGED from the shipped beta.
+   On `dev`, `packages/cli/src/tui.ts` passes a stub `pluginHost: { async start(){}, async dispose(){} }`
+   and `SlotClaim` has zero usages — which would suggest TUI plugins are unimplemented. That is a
+   refactor-in-progress, NOT what ships. `dev`'s `packages/cli` declares only a handful of commands
+   while the shipped binary has many more. Always verify against the installed binary.
+4. Loader entrypoint rule (`packages/opencode/specs/tui-plugins.md`): if a package has an
+   `exports` map, the loader resolves `./tui` or `./server` and **never** falls back to
+   `exports["."]`; `main` is server-only. Hence this package publishes both `./server` and `./tui`.
+   Modules are target-exclusive — a TUI module exporting `server` is rejected, and vice versa.
+5. The root export must NOT statically import `@opentui/solid`. Loading it inside the service
+   process dies with `Environment variable "OPENTUI_FORCE_WCWIDTH" is already registered`, which
+   fails the plugin load. `src/v2/dispatch.ts` therefore lazy-loads the TUI module behind a
+   runtime import and dispatches on context shape.
+
+**Dual-host rule:** v1 files must keep working unchanged against `opencode`. v2 lives under `src/v2/`
+and shares only runtime-agnostic modules (tracker, tokenCounter, config, constants, format).
+Never import `src/ui.ts` or `src/types.ts` event types from v2 code — those are v1-shaped.
 
 ---
 
@@ -37,14 +78,20 @@ OpenCode plugin that tracks AI token throughput in real-time. Displays TPS stati
 
 | Task | Location | Notes |
 |------|----------|-------|
-| Plugin initialization | `src/index.ts:121` | Main export, event handler registration |
-| Event handling | `src/index.ts:359` | message.part.updated, message.updated, session.idle |
-| TPS calculation | `src/tracker.ts:24` | 2-second rolling window, ring buffer |
-| UI display | `src/ui.ts:18` | Throttled updates, toast/TUI dual mode |
-| Token counting | `src/tokenCounter.ts:22` | Heuristic: chars/4, words/0.75, or chars/3 |
-| Configuration | `src/config.ts:231` | Priority: project → global → env |
-| Type definitions | `src/types.ts` | All interfaces exported |
-| Build output | `dist/` | ESM (.mjs) + CJS (.js) + types (.d.ts) |
+| v1 plugin initialization | `src/index.ts:150` | `.server` member of the default export |
+| v1 event handling | `src/index.ts:971` | message.part.updated, message.updated, session.idle |
+| v1 TUI meter | `src/tui.tsx` | `session_prompt_right` slot, `api.event.on` |
+| v2 tracking core | `src/v2/meter.ts:82` | Drives both v2 entries; v2 event vocabulary |
+| v2 TUI meter | `src/v2/tui.tsx:103` | `prompt.footer.status` slot, `ctx.data.on` |
+| v2 server entry | `src/v2/server.ts:44` | `ctx.event.subscribe()` async iterable; no UI surface |
+| v2 API types | `src/v2/types.ts` | Hand-written structural types for the beta v2 API |
+| TPS calculation | `src/tracker.ts:20` | Rolling window, ring buffer (shared v1/v2) |
+| Meter text formatting | `src/format.ts:41` | Shared so v1 and v2 render identically |
+| UI display (v1 only) | `src/ui.ts:19` | Throttled toast updates; no v2 equivalent |
+| Token counting | `src/tokenCounter.ts:129` | Heuristic: chars/4, words/0.75, or chars/3 |
+| Configuration | `src/config.ts:319` | Priority: project → global → env → v2 options |
+| Type definitions | `src/types.ts` | v1 interfaces; v2 types live in `src/v2/types.ts` |
+| Build output | `dist/` | ESM (.mjs) + CJS (.js) + types (.d.ts) + `dist/v2/` |
 
 ---
 
@@ -52,14 +99,19 @@ OpenCode plugin that tracks AI token throughput in real-time. Displays TPS stati
 
 | Symbol | Type | Location | Role |
 |--------|------|----------|------|
-| `TpsMeterPlugin` | Function | `index.ts:121` | Main plugin export, initializes tracking |
-| `createTracker` | Factory | `tracker.ts:24` | TPS tracker with ring buffer |
-| `createUIManager` | Factory | `ui.ts:18` | Display manager with throttling |
-| `createTokenizer` | Factory | `tokenCounter.ts:93` | Heuristic token counter |
-| `loadConfigSync` | Function | `config.ts:231` | Config loader (sync) |
+| `TpsMeterPlugin` | Function | `index.ts:150` | v1 handler factory, exported as the module's `.server` |
+| `createMeter` | Factory | `v2/meter.ts:82` | v2 session tracking core |
+| `setupTui` | Function | `v2/tui.tsx:103` | v2 TUI setup; returns cleanup |
+| `setupServer` | Function | `v2/server.ts:44` | v2 server setup; returns cleanup |
+| `createTracker` | Factory | `tracker.ts:20` | TPS tracker with ring buffer (shared) |
+| `createUIManager` | Factory | `ui.ts:19` | v1 toast display manager with throttling |
+| `createTokenizer` | Factory | `tokenCounter.ts:129` | Heuristic token counter (shared) |
+| `formatMeterText` | Function | `format.ts:41` | Shared meter line rendering |
+| `loadConfigSync` | Function | `config.ts:319` | Config loader (sync), optional overrides |
 | `Config` | Interface | `types.ts:13` | Plugin configuration shape |
-| `TPSTracker` | Interface | `types.ts:316` | Tracker public API |
-| `MessageEvent` | Interface | `types.ts:212` | OpenCode event structure |
+| `TPSTracker` | Interface | `types.ts:363` | Tracker public API |
+| `MessageEvent` | Interface | `types.ts:242` | v1 OpenCode event structure |
+| `V2MeterEvent` | Type | `v2/types.ts` | v2 event union the meter consumes |
 
 ---
 
@@ -102,10 +154,48 @@ OpenCode plugin that tracks AI token throughput in real-time. Displays TPS stati
 - `chars_div_3`: Code-optimized
 - `words_div_0_75`: Prose-optimized
 
-### Event Flow
+### Event Flow (v1)
 1. `message.part.updated` → Count delta tokens → Update tracker → Throttled UI update
 2. `message.updated` (completed) → Show final stats
 3. `session.idle` → Keep latest visible stats after startup delay → cleanup tracker
+
+### Event Flow (v2)
+v2 deleted the whole `message.*` family. Mapping:
+
+| v1 | v2 |
+|----|----|
+| `message.part.delta` (field `text`) | `session.text.delta` |
+| `message.part.updated` (reasoning) | `session.reasoning.delta` |
+| `message.updated` (completed) | `session.step.ended` (same finish reasons) |
+| `message.updated` (`info.tokens`) | `session.usage.updated` |
+| `session.idle` | `session.idle` (unchanged) |
+
+Also changed: event envelope `properties` → `data`; slot `session_prompt_right` →
+`prompt.footer.status`; slot prop `session_id` (required) → `sessionID` (optional);
+theme `current.textMuted` → `text.subdued` and `current.error` → `text.feedback.error.default`;
+`api.event.on` → `ctx.data.on` (TUI) or `ctx.event.subscribe()` async-iterable (server);
+`api.lifecycle.onDispose` → return a cleanup fn from `setup`.
+
+No role filtering is needed on v2 — text/reasoning deltas are assistant output by construction.
+
+**Clock discipline.** The TUI flushes events in ~10ms batches, so `Date.now()` inside a handler
+is FLUSH time and every event in a batch shares it. Use each event's host-stamped `created`
+(`eventTime()` in meter.ts). Note `src/tracker.ts` measures elapsed with its own `Date.now()`,
+so v2 derives elapsed from `firstTokenAt`/`lastTokenAt` instead — never mix the two clocks.
+
+**Cumulative vs per-step.** `session.step.ended.tokens` is a PER-STEP DELTA;
+`session.usage.updated.tokens` is a CUMULATIVE SESSION TOTAL that also includes auto-title and
+compaction. Never substitute one for the other. Their residual is the hidden-overhead metric,
+and it is tracked at SESSION scope (`sessionUsage`) because per-turn state is destroyed on every
+step end and idle.
+
+**Validate at the v2 event boundary.** Event payloads cross a process boundary from the host,
+so `asMeterEvent` rejects anything without a non-empty string `sessionID`, and `toTokenCount`
+coerces provider token fields before arithmetic — a non-numeric `tokens.output` would otherwise
+turn `output + reasoning` into string concatenation (`"100" + "50"` → `"10050"`) and render a
+bogus total. `sweepStaleSessions` drops sessions that go quiet without a terminal event (crash,
+cancel, dropped connection produce neither `session.step.ended` nor `session.idle`), reusing the
+v1 `MAX_MESSAGE_AGE_MS` / `CLEANUP_INTERVAL_MS` thresholds.
 
 ---
 
@@ -131,6 +221,11 @@ bun run build                  # Build dual-format output
 1. `.opencode/tps-meter.json` (project-level)
 2. `~/.config/opencode/tps-meter.json` (global)
 3. Environment variables (`TPS_METER_*`)
+4. Inline overrides — v2 plugin `options` from `opencode.json`, passed as `loadConfigSync(overrides)`
+
+Note v2 dropped `tui.json`/`tui.jsonc` entirely (replaced by one global `cli.json`) and renamed
+the plugin config key from `plugin` to `plugins`. The plugin's own `tps-meter.json` files are
+unaffected.
 
 ### Environment Variables
 - `TPS_METER_ENABLED` (boolean)
@@ -148,5 +243,12 @@ bun run build                  # Build dual-format output
 
 ### Dependencies
 - `@opencode-ai/plugin`: Peer dependency (external in build)
+- `@opentui/solid` / `solid-js`: **optional peer** dependencies, not bundled. The TUI host supplies
+  the renderer and reactive runtime; a nested copy would give the plugin its own reactive graph and
+  the meter would render once and then freeze. v2 pins `@opentui/*` to a dated snapshot
+  (`0.0.0-20260808-*`), which is why the peer range is `*` rather than a semver range.
+- v2 API types are hand-written in `src/v2/types.ts` rather than imported from
+  `@opencode-ai/plugin@next`: v1 and v2 types ship under the same package name so both cannot be
+  installed at once, and the v2 API is beta and still changing.
 - `gpt-tokenizer`: Optional (listed but not actively used - heuristic fallback)
 - `zod`: Listed but not actively used in current implementation

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A live tokens-per-second meter plugin for OpenCode. Track AI token throughput in
 
 ## Features
 
+- **Runs on both OpenCode generations** — one package, v1 (`opencode`) and v2 beta (`opencode2`)
+- **Exact final totals on v2** — provider-reported token counts replace the heuristic estimate when the turn ends
 - **Real-time Monitoring** — Live TPS calculation with configurable rolling window
 - **Smart Filtering** — Tracks only assistant text/reasoning, excludes user prompts, tools, patches, snapshots, and files
 - **Noise Suppression** — TPS display starts after a configurable 10ms startup delay for fast live feedback
@@ -43,7 +45,25 @@ A live tokens-per-second meter plugin for OpenCode. Track AI token throughput in
 
 ---
 
+## OpenCode version support
+
+One package supports both OpenCode generations. They install as separate binaries (`opencode` and `opencode2`) and can run side by side.
+
+| | OpenCode v1 (`opencode`) | OpenCode v2 beta (`opencode2`) |
+|---|---|---|
+| Config key | `"plugin"` | `"plugins"` |
+| Meter renders in | TUI session prompt | TUI prompt footer status |
+| Registered as | `opencode-tps-meter` | `opencode-tps-meter` |
+| Default export shape | function *or* `{ id, server }` | `{ id, setup }` (object required) |
+| Toast fallback | Available (opt-in) | Not available — v2 server plugins have no UI surface |
+
+> **v2 is beta.** Its plugin API is documented as subject to change before 2.0 is stable. Verified against `opencode2` beta `0.0.0-beta-17639`, whose shipped binary implements the v2 TUI plugin API this package targets — its own built-in TUI plugins (`opencode.notifications`, `diff-viewer`) use `Plugin.define({ id, setup })` with `ctx.ui.slot({ append, render })` and `ctx.data.on(...)`.
+
+---
+
 ## Installation
+
+### OpenCode v1
 
 Install with OpenCode's plugin installer so the persistent TUI entrypoint is registered:
 
@@ -59,26 +79,118 @@ For manual installation, add the package to your TUI config (`~/.config/opencode
 }
 ```
 
+### OpenCode v2 (`opencode2`)
+
+v2 replaced layered `tui.json(c)` files with a single global `cli.json`, and renamed the plugin config key to `plugins`. Register in `opencode.json`:
+
+```json
+{
+  "plugins": ["opencode-tps-meter@latest"]
+}
+```
+
+The single package name is all you need — the default export carries both plugin shapes, so v1 reads `server` and v2 reads `setup`.
+
+> **Do not use subpath specifiers in `plugins`.** v2 treats every string in that array as an npm package name or a local path, so `"opencode-tps-meter/v2"` is not resolved as a subpath — it is attempted as a package install and fails. The `opencode-tps-meter/v2` and `/v2/tui` exports exist for programmatic `import` only.
+
+v2 also accepts inline options, which take priority over config files and environment variables:
+
+```json
+{
+  "plugins": [
+    {
+      "package": "opencode-tps-meter@latest",
+      "options": { "showElapsed": true, "enableColorCoding": true }
+    }
+  ]
+}
+```
+
 ---
 
 ## Quick Start
 
-The plugin will automatically hook into OpenCode events and start tracking TPS after installation.
+The plugin hooks into OpenCode events and starts tracking TPS after installation.
 
-On OpenCode versions that support TUI plugins, the package also exposes `opencode-tps-meter/tui`. OpenCode's installer detects that entrypoint; manual installs need the package listed in TUI config for persistent rendering in the session prompt area.
+On v1, the meter renders in the session prompt area via `opencode-tps-meter/tui`. OpenCode's installer detects that entrypoint; manual installs need the package listed in TUI config.
 
-If you intentionally want the old toast UI for an older OpenCode surface, add the package to normal OpenCode plugin config too and set `toastFallback: true` or `TPS_METER_TOAST_FALLBACK=true`.
+On v2, TUI plugins are registered in the global `~/.config/opencode/cli.json` under `plugins` (auto-migrated from v1's `tui.json`). Per OpenCode's loader spec, a package with an `exports` map is resolved via `./tui` or `./server` and **never** falls back to `exports["."]`, so this package publishes both.
+
+**Registering a local checkout on v2:** a path spec must point at the built TUI **file**, not the
+package directory. v2's TUI loader resolves a directory spec by appending `/tui` and opening that path
+literally — it does not consult `package.json` `exports` and does not try extensions, so a directory
+entry fails with `ENOENT ... open '<dir>/tui'`:
+
+```json
+{ "plugins": ["file:///abs/path/to/opencode-tps-meter/dist/tui.mjs"] }
+```
+
+`exports["./tui"]` is only used for npm-package specs (`"opencode-tps-meter"`).
+
+**Note on the v2 TUI module shape:** v2 requires `{ id, setup }`. Plugins exporting only v1's
+`{ id, tui }` are rejected by the loader. This package's TUI module exports both keys, so it satisfies
+v1 and v2 from one file.
+
+v2 ships a plugin manager dialog — open the command palette (`ctrl+p`) and run **Open plugin manager dialog** (`plugins.list`) to see which TUI plugins loaded, and to enable/disable them with `space`. Runtime enable/disable state is persisted and overrides config at startup, so check there first if the meter does not appear.
+
+If you intentionally want the old toast UI on an older v1 surface, add the package to normal OpenCode plugin config too and set `toastFallback: true` or `TPS_METER_TOAST_FALLBACK=true`. This option does nothing on v2.
 
 ### Package Exports
 
-When using the plugin with OpenCode, you only need the default package export. OpenCode TUI plugin loading uses the `opencode-tps-meter/tui` subpath automatically when installed through OpenCode's plugin installer or when listed in TUI config.
+When using the plugin with OpenCode, you only need the default package export for your host generation.
 
 ```typescript
-import TpsMeterPlugin from 'opencode-tps-meter';
-import TpsMeterTuiPlugin from 'opencode-tps-meter/tui';
+import TpsMeterPlugin from 'opencode-tps-meter';          // v1 server (also carries the v2 shape)
+import TpsMeterTuiPlugin from 'opencode-tps-meter/tui';   // v1 TUI (also carries the v2 shape)
+import TpsMeterV2 from 'opencode-tps-meter/v2';           // v2 server only
+import TpsMeterV2Tui from 'opencode-tps-meter/v2/tui';    // v2 TUI only
 ```
 
 Internal tracker/tokenizer/UI helper modules are not public package exports. For experiments or forks, clone the repository and import helpers from local source paths instead of from the published package.
+
+### v2-only capabilities
+
+These need APIs that do not exist on v1, so they are inert on `opencode`.
+
+| Feature | What you get | v2 API |
+|---|---|---|
+| Calibrated live rate | The streaming estimate is corrected against provider token counts, learned per model | `session.step.started` (model/agent) + `session.step.ended` (tokens) |
+| Generation vs end-to-end TPS | Tool execution subtracted, so a turn that waited on a shell command still reports the model's real rate | `session.tool.called` / `.success` / `.failed` |
+| Time to first token | Measured from turn start on the host clock | `session.execution.started` + event `created` |
+| Hidden overhead | Tokens spent on auto-title and compaction that no step reports | `session.usage.updated` residual |
+| Per-subagent breakdown | Sidebar panel with exact parent/child attribution | `ctx.data.session.root` / `.family` |
+| Durable ledger + dashboard | Per-model mean/best throughput and TTFT, persisted and shared across windows | `ctx.storage.store`, `ctx.ui.router` |
+| Wire-level TTFB | Provider dispatch to response headers, below the streaming pipeline | `ctx.session.hook("http.request"/"http.response")` |
+
+Every one of these is feature-detected. A host that exposes none of the optional APIs still gets
+the footer meter and nothing else.
+
+**Commands** (palette, `/tps`, or a key you bind):
+
+```text
+/tps              open the throughput dashboard
+/tps detail       toast with current stats
+/tps detailed     footer shows gen / ttft / overhead
+/tps compact      default footer
+/tps hidden       hide the meter
+/tps reset        clear the durable ledger
+```
+
+**Latency.** Token counting is incremental — each chunk is scanned once and never re-read, so
+absorbing a long response is linear rather than quadratic. On v2 the displayed rate also uses a
+shorter EWMA half-life (120ms vs v1's 250ms), since host-clock timestamps make the rolling
+window accurate enough that extra exponential smoothing mostly just adds lag. The v2 display throttle defaults to 8ms — the host delivers events in ~10ms batches, so
+publishing faster cannot reveal anything new — and the publish itself is synchronous, so a
+delta is visible in about a millisecond. v1 keeps its 50ms default for the costlier toast path.
+Tune with `updateIntervalMs` (display throttle) and `rollingWindowMs` (averaging window); an
+explicit value overrides the default on either host.
+
+**Clock note.** The TUI delivers events in ~10ms batches, so wall-clock time inside a handler is
+flush time shared by the whole batch. All timing uses each event's host-stamped `created`.
+
+### Peer dependencies
+
+`@opentui/solid` and `solid-js` are optional peer dependencies rather than bundled dependencies. The TUI host supplies the renderer and reactive runtime; installing a second copy inside the plugin would give it a separate reactive graph and the meter would render once and never update.
 
 ---
 
@@ -238,10 +350,13 @@ The published package exposes only the OpenCode plugin entrypoints:
 ```typescript
 import TpsMeterPlugin from 'opencode-tps-meter';
 import TpsMeterTuiPlugin from 'opencode-tps-meter/tui';
+import TpsMeterV2 from 'opencode-tps-meter/v2';
+import TpsMeterV2Tui from 'opencode-tps-meter/v2/tui';
 ```
 
-- `opencode-tps-meter` is the legacy server/toast fallback plugin entrypoint. It does not emit toasts unless `toastFallback` is enabled.
-- `opencode-tps-meter/tui` is the persistent OpenCode TUI entrypoint.
+- `opencode-tps-meter` is the v1 server/toast fallback entrypoint. It does not emit toasts unless `toastFallback` is enabled. The exported function also carries `id` and `setup` properties so a v2 host can load the same module.
+- `opencode-tps-meter/tui` is the persistent v1 TUI entrypoint. The exported object carries both `tui` (v1) and `setup` (v2).
+- `opencode-tps-meter/v2` and `opencode-tps-meter/v2/tui` are plain `{ id, setup }` v2 definitions with no callable v1 shape, for hosts that reject the dual-shaped modules.
 
 Tracker, tokenizer, and UI helper modules are internal implementation details and are not exported as public package subpaths. If you need those helpers for experimentation, clone or fork the repository and import them from local source files.
 
@@ -261,7 +376,7 @@ Tracker, tokenizer, and UI helper modules are internal implementation details an
 
 ## How It Works
 
-### Event Handling
+### Event Handling (OpenCode v1)
 
 The plugin subscribes to four OpenCode event types:
 
@@ -289,6 +404,25 @@ The plugin subscribes to four OpenCode event types:
    - Removes tracker for the specific session
    - Clears all session-specific caches (role cache, token cache, part text cache)
    - Preserves completed session stats
+
+### Event Handling (OpenCode v2)
+
+v2 removed the entire `message.*` event family and replaced it with granular session events. The v2 entries subscribe to five:
+
+| v1 event | v2 replacement |
+|---|---|
+| `message.part.delta` (field `text`) | `session.text.delta` |
+| `message.part.updated` (reasoning) | `session.reasoning.delta` |
+| `message.updated` (completed) | `session.step.ended` |
+| `message.updated` (`info.tokens`) | `session.usage.updated` |
+| `session.idle` | `session.idle` (unchanged) |
+
+Two consequences worth knowing:
+
+- **No role filtering is needed.** `session.text.delta` and `session.reasoning.delta` are assistant output by construction, so v1's message-role cache, part-type filtering, and part-text extraction have no v2 equivalent — user prompts can no longer leak into the count.
+- **Final totals are exact, not heuristic.** `session.step.ended` carries provider-reported `tokens.output` and `tokens.reasoning`, which the meter prefers over its own character-based estimate. The heuristic still drives the live rolling rate, since deltas arrive before any usage report.
+
+`session.step.ended` reports the same finish reasons as v1 (`stop`, `length`, `tool-calls`, `content-filter`, `error`, `unknown`), so tool-call and error handling behave identically across both hosts: a `tool-calls` finish freezes the reading on screen instead of clearing it, and `unknown` discards it.
 
 ### Part Types Counted
 
@@ -330,6 +464,8 @@ bun run build
 - `dist/tui.mjs` — OpenCode TUI plugin ESM build
 - `dist/tui.js` — internal CommonJS TUI artifact generated by the build; public TUI loading uses the ESM `opencode-tps-meter/tui` export
 - `dist/tui.d.ts` — OpenCode TUI plugin declarations
+- `dist/v2/server.mjs` — OpenCode v2 server plugin (`opencode-tps-meter/v2`)
+- `dist/v2/tui.mjs` — OpenCode v2 TUI plugin (`opencode-tps-meter/v2/tui`)
 
 **Note:** The CJS build requires a manual export fix for OpenCode compatibility:
 ```typescript
@@ -347,7 +483,10 @@ bun run build
 ### Plugin Not Displaying
 
 - ✅ Verify `TPS_METER_ENABLED` is not set to `false`
-- ✅ For persistent TUI display, install with `opencode plug install opencode-tps-meter@latest` or add the package to OpenCode's TUI config (`~/.config/opencode/tui.json` or `tui.jsonc`)
+- ✅ **v1:** for persistent TUI display, install with `opencode plug install opencode-tps-meter@latest` or add the package to OpenCode's TUI config (`~/.config/opencode/tui.json` or `tui.jsonc`)
+- ✅ **v2:** use the `"plugins"` key, not `"plugin"` — and note `tui.json`/`tui.jsonc` are no longer read at all, having been replaced by a single global `cli.json`
+- ✅ **v2:** if the bare package name does not load, register the explicit entries `opencode-tps-meter/v2` and `opencode-tps-meter/v2/tui`
+- ✅ **v2:** confirm the host supplies `@opentui/solid` and `solid-js`; a nested copy inside the plugin gives the meter its own reactive graph, so it renders once and then freezes
 - ✅ Verify your installed package exposes `opencode-tps-meter/tui` for TUI plugin loading
 - ✅ If you still see a `TPS Meter` popup, you are seeing the old server plugin toast path; remove the package from normal OpenCode plugin config or set `toastFallback: false` / `TPS_METER_TOAST_FALLBACK=false`
 - ✅ For intentional toast fallback, set `toastFallback: true` and check that OpenCode client has `tui.showToast`, `tui.publish`, or `toast.info` methods

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,32 +1,109 @@
-## 🎉 Initial Release v0.1.0
+## v0.4.0 — OpenCode v2 support
 
-First release of OpenCode TPS Meter!
+The plugin now runs on **both** OpenCode generations from one package. Nothing about v1 behaviour changes.
 
-### ✨ Features
+### ✨ Added
 
-- **Real-time TPS calculation** with configurable rolling window
-- **Smart filtering** for assistant messages only
-- **TPS-based color coding** (red/yellow/green)
-- **Multi-session support** with automatic cleanup
-- **Throttled UI updates** to prevent flooding
-- **Zero console logging** (TUI safe)
-- **Dual format builds** (ESM + CJS)
+- **OpenCode v2 (`opencode2`) support** — new `opencode-tps-meter/v2` and `opencode-tps-meter/v2/tui` entry points, built on v2's `Plugin.define({ id, setup })` shape.
+- **Exact final token totals on v2** — `session.step.ended` carries provider-reported `tokens.output` / `tokens.reasoning`, so the closing figure is no longer a character-count estimate. The heuristic still drives the live rolling rate.
+- **Inline plugin options on v2** — values passed via `opencode.json` `plugins[].options` override config files and environment variables.
+- **Dual-shaped default entries** — `opencode-tps-meter` and `opencode-tps-meter/tui` carry both the v1 and v2 plugin shapes, so the bare package name works on either host.
+
+### 📈 v2-only metrics and surfaces
+
+- **Self-calibrating tokenizer** — each step compares streamed heuristic tokens against the
+  provider's reported count and learns a per-model correction (EWMA, fractional carry, samples
+  outside 0.25-4x rejected). The live rate stops being a fixed chars/4 guess.
+- **Generation vs end-to-end throughput** — tool execution is bracketed by
+  `session.tool.called`/`.success` and subtracted, so dead time no longer dilutes the rate.
+- **Time to first token** — measured from `session.execution.started` on the host clock.
+- **Hidden overhead** — the residual between cumulative session usage and the sum of per-step
+  deltas is exactly the auto-title and compaction spend.
+- **Per-subagent sidebar panel** — exact attribution via `ctx.data.session.root`/`.family`,
+  replacing v1's session-ID-comparison heuristic.
+- **Durable ledger and `/tps` dashboard** — per-model mean/best throughput and mean TTFT,
+  persisted through `ctx.storage.store` and live-synced across TUI windows. v1's TUI KV is
+  documented as unsupported in v2, so v1 plugins have no durable state at all.
+- **Wire-level TTFB** — the server half times provider dispatch to response headers via
+  `ctx.session.hook`. Server and TUI are separate processes, so this is exposed to embedders
+  via `getWireTimings()` and cannot currently reach the on-screen meter.
+
+### ⚡ Latency
+
+- **Incremental token counting.** Delta counting re-read the entire accumulated response on
+  every chunk — O(total) per delta, O(n^2) per response. With the word heuristic that measured
+  **10,223ms** to absorb a 186k-character stream (1.7ms of blocking work per delta); it is now
+  **12.2ms**, and linear. Counts are proven identical to the batch counter across every
+  algorithm, corpus and chunk size, including words split across chunk boundaries. The full
+  response text is also no longer retained in memory.
+- **Live updates were being dropped.** `publish()` recorded its timestamp on the host event
+  clock while the throttle timer compared against `Date.now()`, and a timer whose guard failed
+  was discarded without rescheduling — so the meter sat stale until the next delta happened to
+  arrive. Measured over 120 deltas at a 10ms cadence: **8 updates, p50 184ms, p95 450ms**. All
+  scheduling is now decided on one clock and the timer publishes what is pending rather than
+  re-testing its preconditions: **120 updates, p50 15.3ms, p95 18.0ms** — and the p50 is the
+  benchmark's own timer granularity, since the publish is synchronous inside `handleEvent`
+  (~1ms).
+- **v2 display throttle lowered to 8ms** (`V2_UPDATE_INTERVAL_MS`). The host flushes events in
+  ~10ms batches, so this is the floor past which publishing more often cannot reveal anything
+  new. v1 keeps its 50ms default, which exists for the much more expensive toast path; an
+  explicit `updateIntervalMs` still wins on both.
+- **Faster smoothing on v2.** The EWMA half-life is now a tracker option. v2 uses 120ms instead
+  of 250ms, cutting time-to-90%-of-a-steady-rate from **940ms to 540ms**. v1 is untouched:
+  omitting the option behaves exactly as before, and a test asserts it.
+
+### 🐞 Fixed
+
+- **`session.usage.updated` was misused as a per-step total.** It is a cumulative session
+  figure that also includes auto-title and compaction tokens, so a long session reported the
+  whole-session total as a single step's output.
+- **Two clocks were mixed.** Token timestamps came from the host while elapsed came from
+  `src/tracker.ts`'s own `Date.now()`. v2 now derives elapsed from host-stamped first/last
+  token times.
+- **Tool-call steps skipped token accounting**, and overhead was tracked in per-turn state that
+  is destroyed on every step end — so it always read zero. Both now session-scoped.
+
+### 🔄 Changed
+
+- `@opentui/solid` and `solid-js` moved from `dependencies` to **optional peer dependencies**. The TUI host supplies the renderer and reactive runtime; a nested copy would give the plugin a separate reactive graph and the meter would render once and then freeze.
+- Meter text formatting extracted to `src/format.ts` so both hosts render identical output.
+- `loadConfigSync()` accepts an optional overrides argument (backward compatible).
+
+### 📝 Notes on v2
+
+v2 removed the entire `message.*` event family; the meter now consumes `session.text.delta`, `session.reasoning.delta`, `session.step.ended`, `session.usage.updated`, and `session.idle`. Role filtering is gone because text and reasoning deltas are assistant output by construction.
+
+v2 server plugins have no UI surface — no client, no toast API — so on v2 the meter would render exclusively from the TUI entry, and `toastFallback` has no effect.
+
+The v2 TUI plugin API is implemented in the shipped `opencode2` beta: its built-in TUI plugins use
+`Plugin.define({ id, setup })` with `ctx.ui.slot` and `ctx.data.on`, which is exactly what this
+package's v2 TUI entry targets. TUI plugins are registered in `~/.config/opencode/cli.json` under
+`plugins`, and v2 provides a plugin manager dialog (`plugins.list`) for inspecting and toggling them.
+
+**v2 is beta.** Verified loading against `opencode2` beta `0.0.0-beta-17639`.
+
+Two v2 loader constraints drove the final design:
+1. The default export must be an **object**. v2 rejects a callable default with
+   `SchemaError(Expected object at ["default"])`, so the plugin now exports
+   `{ id, server, setup }` — v1 reads `server`, v2 reads `setup`.
+2. v2's `plugins` array does not resolve **subpath** specifiers; each string is treated as an npm
+   package name or local path. Register the bare package name.
 
 ### 📦 Installation
 
-Add to your OpenCode configuration:
-
-```json
-{
-  "plugin": ["opencode-tps-meter@0.1.0"]
-}
-```
-
-Or use latest:
+OpenCode v1:
 
 ```json
 {
   "plugin": ["opencode-tps-meter@latest"]
+}
+```
+
+OpenCode v2 (note the `plugins` key):
+
+```json
+{
+  "plugins": ["opencode-tps-meter@latest"]
 }
 ```
 

--- a/bench/bun-globals.d.ts
+++ b/bench/bun-globals.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Minimal ambient declaration for the Bun globals the benchmarks use.
+ *
+ * Benchmarks are excluded from the package tsconfig (which has rootDir "src" and emits
+ * declarations), so they get their own config. Without this they fail to typecheck and
+ * silently rot.
+ */
+declare const Bun: {
+  gc(force?: boolean): void;
+};

--- a/bench/hotpath.ts
+++ b/bench/hotpath.ts
@@ -1,0 +1,30 @@
+import { createMeter } from "../src/v2/meter.js";
+import { loadConfigSync } from "../src/config.js";
+
+function run(label: string, deltas: number, chunk: string, heuristic: string) {
+  process.env.TPS_METER_FALLBACK_HEURISTIC = heuristic;
+  process.env.TPS_METER_UPDATE_INTERVAL_MS = "50";
+  const meter = createMeter(loadConfigSync());
+  const base = Date.now();
+  const t0 = performance.now();
+  for (let i = 0; i < deltas; i++) {
+    meter.handleEvent({
+      id: `e${i}`, created: base + i * 20, type: "session.text.delta",
+      data: { sessionID: "s", assistantMessageID: "m", ordinal: 0, delta: chunk },
+    } as never);
+  }
+  const t1 = performance.now();
+  meter.dispose();
+  const total = t1 - t0;
+  console.log(`  ${label.padEnd(30)} ${total.toFixed(1).padStart(8)}ms ${((total / deltas) * 1000).toFixed(1).padStart(8)}us/delta`);
+}
+
+const chunk = "the quick brown fox jumps over ";
+console.log("chars/4:");
+run("400 deltas (12k chars)", 400, chunk, "chars_div_4");
+run("2000 deltas (62k chars)", 2000, chunk, "chars_div_4");
+run("6000 deltas (186k chars)", 6000, chunk, "chars_div_4");
+console.log("words/0.75:");
+run("400 deltas (12k chars)", 400, chunk, "words_div_0_75");
+run("2000 deltas (62k chars)", 2000, chunk, "words_div_0_75");
+run("6000 deltas (186k chars)", 6000, chunk, "words_div_0_75");

--- a/bench/latency.ts
+++ b/bench/latency.ts
@@ -1,0 +1,24 @@
+import { createTracker } from "../src/tracker.js";
+import { DEFAULT_EWMA_HALF_LIFE_MS, V2_EWMA_HALF_LIFE_MS } from "../src/constants.js";
+
+/** Time for the smoothed reading to reach 90% of a steady target rate. */
+function convergeMs(halfLife: number, targetTps: number): number {
+  const t = createTracker({ rollingWindowMs: 1000, ewmaHalfLifeMs: halfLife });
+  const base = 1_000_000;
+  const stepMs = 10;
+  const perStep = (targetTps * stepMs) / 1000;
+  for (let i = 1; i <= 600; i++) {
+    t.recordTokens(perStep, base + i * stepMs);
+    if (t.getSmoothedTPS() >= targetTps * 0.9) return i * stepMs;
+  }
+  return -1;
+}
+
+console.log("time for the displayed rate to reach 90% of a 90 TPS stream:");
+for (const [label, hl] of [
+  ["v1 default", DEFAULT_EWMA_HALF_LIFE_MS],
+  ["v2 default", V2_EWMA_HALF_LIFE_MS],
+] as const) {
+  const ms = convergeMs(hl, 90);
+  console.log(`  ${label.padEnd(12)} half-life ${String(hl).padStart(4)}ms -> ${String(ms).padStart(4)}ms`);
+}

--- a/bench/memory.ts
+++ b/bench/memory.ts
@@ -1,0 +1,63 @@
+import { createMeter } from "../src/v2/meter.js";
+import { loadConfigSync } from "../src/config.js";
+
+const chunk = "the quick brown fox jumps over the lazy dog ";
+
+function mb(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(1) + "MB";
+}
+
+async function settle() {
+  Bun.gc(true);
+  await new Promise((r) => setTimeout(r, 20));
+  Bun.gc(true);
+}
+
+async function scenario(label: string, run: (m: ReturnType<typeof createMeter>) => void) {
+  await settle();
+  const before = process.memoryUsage().heapUsed;
+  const meter = createMeter(loadConfigSync());
+  run(meter);
+  await settle();
+  const peak = process.memoryUsage().heapUsed;
+  meter.dispose();
+  await settle();
+  const after = process.memoryUsage().heapUsed;
+  console.log(
+    `  ${label.padEnd(46)} retained=${mb(peak - before).padStart(8)}  after dispose=${mb(after - before).padStart(8)}`
+  );
+}
+
+process.env.TPS_METER_UPDATE_INTERVAL_MS = "8";
+const base = Date.now();
+
+// One very long response: 20k deltas ~= 880k characters.
+await scenario("single 880k-char response (20k deltas)", (m) => {
+  for (let i = 0; i < 20_000; i++) {
+    m.handleEvent({ id: `e${i}`, created: base + i * 2, type: "session.text.delta",
+      data: { sessionID: "s", assistantMessageID: "m", ordinal: 0, delta: chunk } } as never);
+  }
+});
+
+// Many messages in one session, each properly settled.
+await scenario("500 settled steps in one session", (m) => {
+  for (let msg = 0; msg < 500; msg++) {
+    for (let i = 0; i < 20; i++) {
+      m.handleEvent({ id: `d${msg}-${i}`, created: base + msg * 100 + i, type: "session.text.delta",
+        data: { sessionID: "s", assistantMessageID: `m${msg}`, ordinal: 0, delta: chunk } } as never);
+    }
+    m.handleEvent({ id: `x${msg}`, created: base + msg * 100 + 50, type: "session.step.ended",
+      data: { sessionID: "s", assistantMessageID: `m${msg}`, finish: "stop", cost: 0,
+        tokens: { input: 0, output: 100, reasoning: 0, cache: { read: 0, write: 0 } } } } as never);
+  }
+});
+
+// Many sessions that never terminate (crash / disconnect path).
+await scenario("2000 abandoned sessions (no terminal event)", (m) => {
+  for (let s = 0; s < 2000; s++) {
+    for (let i = 0; i < 5; i++) {
+      m.handleEvent({ id: `a${s}-${i}`, created: base + i, type: "session.text.delta",
+        data: { sessionID: `s${s}`, assistantMessageID: "m", ordinal: 0, delta: chunk } } as never);
+    }
+  }
+});

--- a/bench/profile.ts
+++ b/bench/profile.ts
@@ -1,0 +1,60 @@
+import { createMeter } from "../src/v2/meter.js";
+import { createTracker } from "../src/tracker.js";
+import { createIncrementalCounter } from "../src/tokenCounter.js";
+import { loadConfigSync } from "../src/config.js";
+
+const N = 50_000;
+const chunk = "the quick brown fox jumps over ";
+
+function bench(label: string, fn: () => void, n = N) {
+  fn(); // warm
+  const t0 = performance.now();
+  for (let i = 0; i < n; i++) fn();
+  const total = performance.now() - t0;
+  console.log(`  ${label.padEnd(38)} ${((total / n) * 1000).toFixed(2).padStart(8)}us/op`);
+}
+
+console.log("component costs:");
+const counter = createIncrementalCounter("heuristic");
+bench("incrementalCounter.add", () => { counter.add(chunk); });
+
+const tracker = createTracker({ rollingWindowMs: 1000 });
+let ts = Date.now();
+bench("tracker.recordTokens", () => { tracker.recordTokens(8, (ts += 2)); });
+bench("tracker.getSmoothedTPS", () => { tracker.getSmoothedTPS(); });
+bench("tracker.getAverageTPS", () => { tracker.getAverageTPS(); });
+
+console.log("");
+console.log("end-to-end handleEvent (publish path included):");
+process.env.TPS_METER_UPDATE_INTERVAL_MS = "8";
+const meter = createMeter(loadConfigSync());
+let i = 0;
+const base = Date.now();
+bench("handleEvent(text.delta)", () => {
+  meter.handleEvent({
+    id: `e${i}`, created: base + i * 2, type: "session.text.delta",
+    data: { sessionID: "s", assistantMessageID: "m", ordinal: 0, delta: chunk },
+  } as never);
+  i++;
+});
+meter.dispose();
+
+console.log("");
+console.log("publish path in isolation (many sessions -> Map copy cost):");
+for (const sessions of [1, 5, 25]) {
+  const m = createMeter(loadConfigSync());
+  const b = Date.now();
+  for (let s = 0; s < sessions; s++) {
+    for (let k = 0; k < 3; k++) {
+      m.handleEvent({ id: `w${s}${k}`, created: b + k * 20, type: "session.text.delta",
+        data: { sessionID: `s${s}`, assistantMessageID: "m", ordinal: 0, delta: chunk } } as never);
+    }
+  }
+  let j = 0;
+  bench(`  ${sessions} active session(s)`, () => {
+    m.handleEvent({ id: `p${j}`, created: b + 1000 + j * 20, type: "session.text.delta",
+      data: { sessionID: "s0", assistantMessageID: "m", ordinal: 0, delta: chunk } } as never);
+    j++;
+  }, 20_000);
+  m.dispose();
+}

--- a/bench/publish.ts
+++ b/bench/publish.ts
@@ -1,0 +1,45 @@
+import { createMeter } from "../src/v2/meter.js";
+import { loadConfigSync } from "../src/config.js";
+
+/**
+ * Simulates the host's ~10ms event batches and measures, for each delta, how long until the
+ * snapshot the UI reads actually reflects it.
+ */
+async function measure(label: string, intervalMs?: number) {
+  if (intervalMs === undefined) delete process.env.TPS_METER_UPDATE_INTERVAL_MS;
+  else process.env.TPS_METER_UPDATE_INTERVAL_MS = String(intervalMs);
+
+  const config = loadConfigSync();
+  const meter = createMeter(config);
+  const lags: number[] = [];
+  let pending: number | null = null;
+
+  meter.subscribe(() => {
+    if (pending !== null) {
+      lags.push(performance.now() - pending);
+      pending = null;
+    }
+  });
+
+  const base = Date.now();
+  for (let i = 0; i < 120; i++) {
+    if (pending === null) pending = performance.now();
+    meter.handleEvent({
+      id: `e${i}`, created: base + i * 10, type: "session.text.delta",
+      data: { sessionID: "s", assistantMessageID: "m", ordinal: 0, delta: "some streamed text " },
+    } as never);
+    await new Promise((r) => setTimeout(r, 10)); // host batch cadence
+  }
+  meter.dispose();
+
+  lags.sort((a, b) => a - b);
+  const p50 = lags[Math.floor(lags.length * 0.5)] ?? 0;
+  const p95 = lags[Math.floor(lags.length * 0.95)] ?? 0;
+  console.log(
+    `  ${label.padEnd(26)} updates=${String(lags.length).padStart(3)}  p50=${p50.toFixed(1).padStart(6)}ms  p95=${p95.toFixed(1).padStart(6)}ms`
+  );
+}
+
+console.log("delta -> visible snapshot latency (120 deltas at 10ms cadence):");
+await measure("config default", undefined);
+await measure("explicit 10ms", 10);

--- a/bench/tsconfig.json
+++ b/bench/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "..",
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/bench/v1path.ts
+++ b/bench/v1path.ts
@@ -1,0 +1,48 @@
+import plugin from "../src/index.js";
+
+const logger = { debug() {}, info() {}, warn() {}, error() {} };
+const chunk = "the quick brown fox jumps over ";
+
+async function run(label: string, deltas: number, heuristic: string) {
+  process.env.TPS_METER_FALLBACK_HEURISTIC = heuristic;
+  process.env.TPS_METER_TOAST_FALLBACK = "false";
+  const handlers = plugin.server({ logger, client: {} } as never) as {
+    event: (a: { event: unknown }) => void;
+  };
+
+  handlers.event({
+    event: {
+      type: "message.updated",
+      properties: {
+        info: { id: "m", sessionID: "s", role: "assistant", time: { created: Date.now() } },
+      },
+    },
+  });
+
+  Bun.gc(true);
+  const heapBefore = process.memoryUsage().heapUsed;
+  const t0 = performance.now();
+  for (let i = 0; i < deltas; i++) {
+    handlers.event({
+      event: {
+        type: "message.part.delta",
+        properties: { sessionID: "s", messageID: "m", partID: "p", delta: chunk },
+      },
+    });
+  }
+  const total = performance.now() - t0;
+  Bun.gc(true);
+  const heapAfter = process.memoryUsage().heapUsed;
+  const chars = deltas * chunk.length;
+  console.log(
+    `  ${label.padEnd(30)} ${total.toFixed(1).padStart(9)}ms  ${((total / deltas) * 1000).toFixed(1).padStart(8)}us/delta  heap+${((heapAfter - heapBefore) / 1024 / 1024).toFixed(1)}MB for ${(chars / 1000).toFixed(0)}k chars`
+  );
+}
+
+console.log("v1 server plugin delta path (chars/4):");
+await run("400 deltas", 400, "chars_div_4");
+await run("2000 deltas", 2000, "chars_div_4");
+await run("6000 deltas", 6000, "chars_div_4");
+console.log("v1 server plugin delta path (words/0.75):");
+await run("400 deltas", 400, "words_div_0_75");
+await run("2000 deltas", 2000, "words_div_0_75");

--- a/build.ts
+++ b/build.ts
@@ -4,10 +4,19 @@ import path from "path";
 async function build(): Promise<void> {
   const srcDir = path.join(import.meta.dir, "src");
   const outDir = path.join(import.meta.dir, "dist");
-  const entrypoints = [path.join(srcDir, "index.ts"), path.join(srcDir, "tui.tsx")];
+  const entrypoints = [
+    path.join(srcDir, "index.ts"),
+    path.join(srcDir, "tui.tsx"),
+    // Dedicated v2 (opencode2) entries. The v1 entries above also carry the v2 shape,
+    // but these give v2 users an unambiguous target with no callable v1 export.
+    path.join(srcDir, "v2", "server.ts"),
+    path.join(srcDir, "v2", "tui.tsx"),
+  ];
   const external = [
     "@opencode-ai/plugin",
     "@opencode-ai/plugin/tui",
+    "@opencode-ai/plugin/v1",
+    "@opencode-ai/plugin/v1/tui",
     "@opentui/core",
     "@opentui/keymap",
     "@opentui/solid",
@@ -21,9 +30,11 @@ async function build(): Promise<void> {
   const esmResult = await Bun.build({
     entrypoints,
     outdir: outDir,
+    root: srcDir,
     format: "esm",
     naming: {
-      entry: "[name].mjs",
+      // [dir] keeps src/v2/* under dist/v2/*, so v2/tui does not collide with tui.
+      entry: "[dir]/[name].mjs",
     },
     target: "node",
     external,
@@ -41,9 +52,10 @@ async function build(): Promise<void> {
   const cjsResult = await Bun.build({
     entrypoints,
     outdir: outDir,
+    root: srcDir,
     format: "cjs",
     naming: {
-      entry: "[name].js",
+      entry: "[dir]/[name].js",
     },
     target: "node",
     external,
@@ -103,6 +115,8 @@ async function build(): Promise<void> {
   console.log("  - dist/index.js (CommonJS - OpenCode compatible)");
   console.log("  - dist/tui.mjs (TUI plugin)");
   console.log("  - dist/tui.js (internal CommonJS TUI artifact, not package-exported)");
+  console.log("  - dist/v2/server.mjs (opencode2 server plugin)");
+  console.log("  - dist/v2/tui.mjs (opencode2 TUI plugin)");
   console.log("  - dist/index.d.ts (TypeScript declarations)");
   console.log("  - dist/tui.d.ts (TUI declarations)");
 }

--- a/bun.lock
+++ b/bun.lock
@@ -4,19 +4,24 @@
   "workspaces": {
     "": {
       "name": "opencode-tps-meter",
-      "dependencies": {
-        "@opentui/solid": "^0.3.0",
-        "solid-js": "1.9.12",
-      },
       "devDependencies": {
         "@opencode-ai/plugin": "^1.15.13",
         "@opentui/core": "^0.3.0",
+        "@opentui/solid": "^0.3.0",
         "@types/node": "^20.0.0",
+        "solid-js": "1.9.12",
         "typescript": "^5.0.0",
       },
       "peerDependencies": {
         "@opencode-ai/plugin": ">=1.15.13",
+        "@opentui/solid": "*",
+        "solid-js": ">=1.9.0",
       },
+      "optionalPeers": [
+        "@opencode-ai/plugin",
+        "@opentui/solid",
+        "solid-js",
+      ],
     },
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-tps-meter",
-  "version": "0.3.1",
-  "description": "Live tokens-per-second meter for OpenCode",
+  "version": "0.4.0",
+  "description": "Live tokens-per-second meter for OpenCode (v1 and v2)",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -17,9 +17,21 @@
         "default": "./dist/index.js"
       }
     },
+    "./server": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    },
     "./tui": {
       "types": "./dist/tui.d.ts",
       "import": "./dist/tui.mjs"
+    },
+    "./v2": {
+      "types": "./dist/v2/server.d.ts",
+      "import": "./dist/v2/server.mjs"
+    },
+    "./v2/tui": {
+      "types": "./dist/v2/tui.d.ts",
+      "import": "./dist/v2/tui.mjs"
     }
   },
   "files": [
@@ -30,7 +42,10 @@
   "scripts": {
     "build": "bun run build.ts",
     "test": "bun test",
-    "prepublishOnly": "bun run build"
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "bun run build",
+    "typecheck:bench": "tsc -p bench/tsconfig.json",
+    "bench": "bun bench/hotpath.ts && bun bench/publish.ts && bun bench/profile.ts && bun bench/memory.ts && bun bench/v1path.ts"
   },
   "repository": {
     "type": "git",
@@ -38,22 +53,34 @@
   },
   "homepage": "https://github.com/ChiR24/opencode-tps-meter#readme",
   "bugs": "https://github.com/ChiR24/opencode-tps-meter/issues",
-  "dependencies": {
-    "@opentui/solid": "^0.3.0",
-    "solid-js": "1.9.12"
-  },
   "devDependencies": {
     "@opencode-ai/plugin": "^1.15.13",
     "@opentui/core": "^0.3.0",
+    "@opentui/solid": "^0.3.0",
+    "solid-js": "1.9.12",
     "typescript": "^5.0.0",
     "@types/node": "^20.0.0"
   },
   "peerDependencies": {
-    "@opencode-ai/plugin": ">=1.15.13"
+    "@opencode-ai/plugin": ">=1.15.13",
+    "@opentui/solid": "*",
+    "solid-js": ">=1.9.0"
+  },
+  "peerDependenciesMeta": {
+    "@opencode-ai/plugin": {
+      "optional": true
+    },
+    "@opentui/solid": {
+      "optional": true
+    },
+    "solid-js": {
+      "optional": true
+    }
   },
   "keywords": [
     "opencode",
     "opencode-plugin",
+    "opencode2",
     "ai",
     "tokens"
   ],

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -13,10 +13,15 @@ import * as path from "path";
 import * as os from "os";
 
 describe("E2E: Module Exports", () => {
-  it("should export the main plugin function as default", async () => {
+  it("should export the dual-host plugin module as default", async () => {
     const module = await import("../index.js");
     expect(module.default).toBeDefined();
-    expect(typeof module.default).toBe("function");
+    // Must be an OBJECT, not a function: v2 validates the default export against a schema
+    // requiring an object and rejects a callable with `Expected object at ["default"]`.
+    expect(typeof module.default).toBe("object");
+    expect(module.default.id).toBe("opencode-tps-meter");
+    expect(typeof module.default.server).toBe("function");
+    expect(typeof module.default.setup).toBe("function");
     expect(Object.keys(module)).toEqual(["default"]);
   });
 });
@@ -57,7 +62,7 @@ describe("E2E: Plugin Loading", () => {
   });
 
   it("should load successfully with a mock OpenCode context", async () => {
-    const { default: TpsMeterPlugin } = await import("../index.js");
+    const { default: { server: TpsMeterPlugin } } = await import("../index.js");
 
     const mockContext = {
       client: {
@@ -92,7 +97,7 @@ describe("E2E: Plugin Loading", () => {
   it("should return empty handlers when plugin is disabled", async () => {
     process.env.TPS_METER_ENABLED = "false";
 
-    const { default: TpsMeterPlugin } = await import("../index.js");
+    const { default: { server: TpsMeterPlugin } } = await import("../index.js");
 
     const mockContext = {
       client: {},

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -13,7 +13,10 @@ import type {
   Logger,
   Part,
 } from "../types.js";
-import TpsMeterPlugin from "../index.js";
+import tpsMeterModule from "../index.js";
+
+// v1 entry point lives on `.server`; the default export is the dual-host module object.
+const TpsMeterPlugin = tpsMeterModule.server;
 
 const MIN_TPS_ELAPSED_MS = 250;
 

--- a/src/__tests__/multi-agent.test.ts
+++ b/src/__tests__/multi-agent.test.ts
@@ -16,7 +16,10 @@ import type {
   Logger,
   AgentIdentity,
 } from "../types.js";
-import TpsMeterPlugin from "../index.js";
+import tpsMeterModule from "../index.js";
+
+// v1 entry point lives on `.server`; the default export is the dual-host module object.
+const TpsMeterPlugin = tpsMeterModule.server;
 
 const MIN_TPS_ELAPSED_MS = 250;
 

--- a/src/__tests__/v2.test.ts
+++ b/src/__tests__/v2.test.ts
@@ -576,9 +576,10 @@ describe("v2 plugin entries", () => {
     } as never);
 
     expect(claims).toHaveLength(1);
-    // Must PREPEND: the host's own flexGrow:1 child would squeeze an appended
-    // meter to zero width whenever a turn is running.
-    expect(claims[0]?.prepend).toBe("prompt.footer.status");
+    // Must be a SIBLING (`after`), not a child: the host's own flexGrow:1 child inside
+    // this slot squeezes anything appended within the boundary to zero width whenever a
+    // turn is running.
+    expect(claims[0]?.after).toBe("prompt.footer.status");
     expect(typeof claims[0]?.render).toBe("function");
 
     // The v2 events that replace v1's message.* family, plus the step/tool/execution
@@ -1003,7 +1004,7 @@ describe("v2 optional surfaces", () => {
       },
     } as never);
 
-    const targets = claims.map((c) => c.append ?? c.prepend).sort();
+    const targets = claims.map((c) => c.append ?? c.prepend ?? c.after).sort();
     expect(targets).toEqual(["app", "prompt.footer.status", "sidebar.content"]);
     expect(routes).toHaveLength(1);
     expect(routes[0]?.name).toBe("tps");
@@ -1043,7 +1044,7 @@ describe("v2 optional surfaces", () => {
       },
     } as never);
 
-    expect(claims.map((c) => c.append ?? c.prepend)).toEqual(["prompt.footer.status"]);
+    expect(claims.map((c) => c.append ?? c.prepend ?? c.after)).toEqual(["prompt.footer.status"]);
     await (cleanup as () => void | Promise<void>)();
   });
 });
@@ -1340,7 +1341,7 @@ describe("v2 resilience", () => {
       ui: {
         slot: (claim: Record<string, unknown>) => {
           claims.push(claim);
-          if (claim.prepend !== "prompt.footer.status") boom();
+          if (claim.after !== "prompt.footer.status") boom();
           return () => {};
         },
         toast: { show: boom },
@@ -1351,7 +1352,7 @@ describe("v2 resilience", () => {
     } as never);
 
     // The one surface that must survive.
-    expect(claims.some((c) => c.prepend === "prompt.footer.status")).toBe(true);
+    expect(claims.some((c) => c.after === "prompt.footer.status")).toBe(true);
     expect(typeof cleanup).toBe("function");
     await (cleanup as () => void | Promise<void>)();
   });

--- a/src/__tests__/v2.test.ts
+++ b/src/__tests__/v2.test.ts
@@ -1,0 +1,1402 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { createMeter, type V2Snapshot } from "../v2/meter.js";
+import { loadConfigSync } from "../config.js";
+import type { V2UnknownEvent } from "../v2/types.js";
+
+const stableEnv = {
+  TPS_METER_ENABLED: "true",
+  TPS_METER_UPDATE_INTERVAL_MS: "50",
+  TPS_METER_INITIAL_DISPLAY_DELAY_MS: "10",
+  TPS_METER_ROLLING_WINDOW_MS: "1000",
+  TPS_METER_SHOW_AVERAGE: "true",
+  TPS_METER_SHOW_INSTANT: "true",
+  TPS_METER_SHOW_TOTAL_TOKENS: "true",
+  TPS_METER_SHOW_ELAPSED: "false",
+  TPS_METER_FORMAT: "compact",
+  TPS_METER_MIN_VISIBLE_TPS: "0",
+  TPS_METER_FALLBACK_HEURISTIC: "chars_div_4",
+  TPS_METER_ENABLE_COLOR_CODING: "false",
+  TPS_METER_SLOW_TPS_THRESHOLD: "10",
+  TPS_METER_FAST_TPS_THRESHOLD: "50",
+} as const;
+
+const originalEnv = new Map<keyof typeof stableEnv, string | undefined>();
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+let eventId = 0;
+
+function textDelta(sessionID: string, delta: string, messageID = "msg_1"): V2UnknownEvent {
+  eventId += 1;
+  return {
+    id: `evt_${eventId}`,
+    created: Date.now(),
+    type: "session.text.delta",
+    data: { sessionID, assistantMessageID: messageID, ordinal: 0, delta },
+  };
+}
+
+function reasoningDelta(sessionID: string, delta: string, messageID = "msg_1"): V2UnknownEvent {
+  eventId += 1;
+  return {
+    id: `evt_${eventId}`,
+    created: Date.now(),
+    type: "session.reasoning.delta",
+    data: { sessionID, assistantMessageID: messageID, ordinal: 0, delta },
+  };
+}
+
+function stepEnded(
+  sessionID: string,
+  finish: string,
+  tokens?: { output: number; reasoning: number },
+  messageID = "msg_1"
+): V2UnknownEvent {
+  eventId += 1;
+  return {
+    id: `evt_${eventId}`,
+    created: Date.now(),
+    type: "session.step.ended",
+    data: {
+      sessionID,
+      assistantMessageID: messageID,
+      finish,
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: tokens?.output ?? 0,
+        reasoning: tokens?.reasoning ?? 0,
+        cache: { read: 0, write: 0 },
+      },
+    },
+  };
+}
+
+function sessionIdle(sessionID: string): V2UnknownEvent {
+  eventId += 1;
+  return {
+    id: `evt_${eventId}`,
+    created: Date.now(),
+    type: "session.idle",
+    data: { sessionID },
+  };
+}
+
+describe("v2 meter", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      originalEnv.set(key, process.env[key]);
+      process.env[key] = stableEnv[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      const previous = originalEnv.get(key);
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+    originalEnv.clear();
+  });
+
+  function createHarness() {
+    const config = loadConfigSync();
+    const meter = createMeter(config);
+    return {
+      meter,
+      config,
+      snapshot: (sessionID: string): V2Snapshot | undefined =>
+        meter.getSnapshots().get(sessionID),
+    };
+  }
+
+  it("publishes a live snapshot from session.text.delta after the startup delay", async () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "hello there, streaming tokens"));
+    expect(snapshot("ses_1")).toBeUndefined();
+
+    await delay(40);
+
+    const current = snapshot("ses_1");
+    expect(current).toBeDefined();
+    expect(current?.active).toBe(true);
+    expect(current?.totalTokens).toBeGreaterThan(0);
+
+    meter.dispose();
+  });
+
+  it("counts reasoning deltas alongside text deltas", async () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "abcdefgh"));
+    await delay(40);
+    const afterText = snapshot("ses_1")?.totalTokens ?? 0;
+
+    meter.handleEvent(reasoningDelta("ses_1", "ijklmnopqrstuvwx"));
+    await delay(80);
+
+    expect(snapshot("ses_1")?.totalTokens ?? 0).toBeGreaterThan(afterText);
+
+    meter.dispose();
+  });
+
+  it("counts cumulative stream text rather than rounding each chunk", async () => {
+    const { meter, snapshot } = createHarness();
+
+    // Twelve 1-char deltas: per-chunk chars/4 would round each up, cumulative gives 3.
+    for (const char of "abcdefghijkl") {
+      meter.handleEvent(textDelta("ses_1", char));
+    }
+    await delay(40);
+
+    expect(snapshot("ses_1")?.totalTokens).toBe(3);
+
+    meter.dispose();
+  });
+
+  it("prefers provider-reported tokens over the streamed heuristic at step end", async () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "short"));
+    await delay(40);
+
+    meter.handleEvent(stepEnded("ses_1", "stop", { output: 500, reasoning: 100 }));
+
+    const final = snapshot("ses_1");
+    expect(final?.totalTokens).toBe(600);
+    expect(final?.active).toBe(false);
+    expect(final?.avgTps).toBeGreaterThan(0);
+
+    meter.dispose();
+  });
+
+  it("falls back to streamed counts when a step reports no tokens", async () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "abcdefghijkl"));
+    await delay(40);
+
+    meter.handleEvent(stepEnded("ses_1", "stop"));
+
+    expect(snapshot("ses_1")?.totalTokens).toBe(3);
+
+    meter.dispose();
+  });
+
+  it("keeps the reading visible when a step ends for tool calls", async () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "streaming before a tool call"));
+    await delay(40);
+    expect(snapshot("ses_1")?.active).toBe(true);
+
+    meter.handleEvent(stepEnded("ses_1", "tool-calls", { output: 40, reasoning: 0 }));
+
+    const persisted = snapshot("ses_1");
+    expect(persisted).toBeDefined();
+    expect(persisted?.active).toBe(false);
+    expect(persisted?.totalTokens).toBeGreaterThan(0);
+
+    meter.dispose();
+  });
+
+  it("clears the active reading on an unknown finish reason", async () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "streaming that will be invalidated"));
+    await delay(40);
+    expect(snapshot("ses_1")?.active).toBe(true);
+
+    meter.handleEvent(stepEnded("ses_1", "unknown"));
+
+    expect(snapshot("ses_1")).toBeUndefined();
+
+    meter.dispose();
+  });
+
+  it("keeps the latest reading visible after the session idles", async () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "streaming then going idle"));
+    await delay(40);
+
+    meter.handleEvent(sessionIdle("ses_1"));
+
+    const persisted = snapshot("ses_1");
+    expect(persisted).toBeDefined();
+    expect(persisted?.active).toBe(false);
+
+    meter.dispose();
+  });
+
+  it("does not persist a reading when idling before the startup delay", () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "too fast to display"));
+    meter.handleEvent(sessionIdle("ses_1"));
+
+    expect(snapshot("ses_1")).toBeUndefined();
+
+    meter.dispose();
+  });
+
+  it("keeps sessions isolated", async () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "abcdefghijkl", "msg_a"));
+    meter.handleEvent(textDelta("ses_2", "abcdefghijklmnopqrstuvwx", "msg_b"));
+    await delay(40);
+
+    expect(snapshot("ses_1")?.totalTokens).toBe(3);
+    expect(snapshot("ses_2")?.totalTokens).toBe(6);
+
+    meter.handleEvent(stepEnded("ses_1", "unknown", undefined, "msg_a"));
+
+    expect(snapshot("ses_1")).toBeUndefined();
+    expect(snapshot("ses_2")).toBeDefined();
+
+    meter.dispose();
+  });
+
+  it("never substitutes cumulative session usage for a single step's total", async () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "abcd")); // 4 chars -> 1 heuristic token
+    await delay(40);
+
+    // session.usage.updated is a CUMULATIVE SESSION total published from the accumulated
+    // session row — it also includes auto-title generation and compaction tokens. Using it
+    // as a per-step fallback reported 300 tokens for a 1-token step.
+    eventId += 1;
+    meter.handleEvent({
+      id: `evt_${eventId}`,
+      created: Date.now(),
+      type: "session.usage.updated",
+      data: {
+        sessionID: "ses_1",
+        cost: 0,
+        tokens: { input: 10, output: 250, reasoning: 50, cache: { read: 0, write: 0 } },
+      },
+    });
+    meter.handleEvent(stepEnded("ses_1", "stop"));
+
+    expect(snapshot("ses_1")?.totalTokens).toBe(1);
+
+    meter.dispose();
+  });
+
+  it("derives hidden overhead as cumulative usage minus observed step deltas", async () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "abcd"));
+    await delay(40);
+
+    // Step reports 100 real output tokens...
+    meter.handleEvent(stepEnded("ses_1", "tool-calls", { output: 100, reasoning: 0 }));
+    // ...but the session was billed 130 cumulative. The 30 difference is auto-title and
+    // compaction work the user never asked for.
+    eventId += 1;
+    meter.handleEvent({
+      id: `evt_${eventId}`,
+      created: Date.now(),
+      type: "session.usage.updated",
+      data: {
+        sessionID: "ses_1",
+        cost: 0,
+        tokens: { input: 0, output: 130, reasoning: 0, cache: { read: 0, write: 0 } },
+      },
+    });
+
+    meter.handleEvent(textDelta("ses_1", "efgh"));
+    await delay(60);
+
+    expect(snapshot("ses_1")?.overheadTokens).toBe(30);
+
+    meter.dispose();
+  });
+
+  it("reports zero overhead before any cumulative usage arrives", async () => {
+    const { meter, snapshot } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "abcdefghijkl"));
+    await delay(40);
+
+    expect(snapshot("ses_1")?.overheadTokens).toBe(0);
+
+    meter.dispose();
+  });
+
+  it("ignores non-numeric provider token counts instead of concatenating them", async () => {
+    const { meter, snapshot } = createHarness();
+    meter.handleEvent(textDelta("ses_1", "abcdefghijkl"));
+    await delay(40);
+
+    // A string field would make `output + reasoning` string-concatenate to "10050".
+    eventId += 1;
+    meter.handleEvent({
+      id: `evt_${eventId}`,
+      created: Date.now(),
+      type: "session.step.ended",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_1",
+        finish: "stop",
+        cost: 0,
+        tokens: { input: 0, output: "100", reasoning: "50", cache: { read: 0, write: 0 } },
+      },
+    } as unknown as V2UnknownEvent);
+
+    expect(typeof snapshot("ses_1")?.totalTokens).toBe("number");
+    expect(snapshot("ses_1")?.totalTokens).toBe(3);
+    meter.dispose();
+  });
+
+  it("ignores negative and non-finite token counts", async () => {
+    const { meter, snapshot } = createHarness();
+    meter.handleEvent(textDelta("ses_1", "abcdefghijkl"));
+    await delay(40);
+
+    eventId += 1;
+    meter.handleEvent({
+      id: `evt_${eventId}`,
+      created: Date.now(),
+      type: "session.step.ended",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_1",
+        finish: "stop",
+        cost: 0,
+        tokens: { input: 0, output: -500, reasoning: Number.NaN, cache: { read: 0, write: 0 } },
+      },
+    } as unknown as V2UnknownEvent);
+
+    expect(snapshot("ses_1")?.totalTokens).toBe(3);
+    meter.dispose();
+  });
+
+  it("drops events with a missing or non-string sessionID", async () => {
+    const { meter } = createHarness();
+    for (const bad of [undefined, 42, ""]) {
+      eventId += 1;
+      meter.handleEvent({
+        id: `evt_${eventId}`,
+        created: Date.now(),
+        type: "session.text.delta",
+        data: { sessionID: bad, assistantMessageID: "msg_1", ordinal: 0, delta: "text" },
+      } as unknown as V2UnknownEvent);
+    }
+    await delay(40);
+    expect(meter.getSnapshots().size).toBe(0);
+    meter.dispose();
+  });
+
+  it("frees state for abandoned sessions but keeps the reading on screen", async () => {
+    const { meter } = createHarness();
+    const { CLEANUP_INTERVAL_MS, MAX_MESSAGE_AGE_MS } = await import("../constants.js");
+
+    const realNow = Date.now;
+    let clock = realNow.call(Date);
+    Date.now = () => clock;
+
+    try {
+      // A turn that streams and then vanishes: no step.ended, no session.idle.
+      meter.handleEvent(textDelta("ses_abandoned", "streaming then disconnected"));
+      clock += 40;
+      meter.handleEvent(textDelta("ses_abandoned", " more text"));
+      expect(meter.getSnapshots().has("ses_abandoned")).toBe(true);
+
+      clock += MAX_MESSAGE_AGE_MS + CLEANUP_INTERVAL_MS + 1;
+      meter.handleEvent(textDelta("ses_live", "a new session arrives"));
+
+      // v1 left the final numbers on screen forever; deleting them here made the meter
+      // appear to forget after five quiet minutes. Only the heavy state is freed.
+      const kept = meter.getSnapshots().get("ses_abandoned");
+      expect(kept).toBeDefined();
+      expect(kept?.active).toBe(true);
+    } finally {
+      Date.now = realNow;
+      meter.dispose();
+    }
+  });
+
+  it("caps how many frozen readings it retains", async () => {
+    const { meter } = createHarness();
+    const { CLEANUP_INTERVAL_MS, MAX_MESSAGE_AGE_MS, MAX_RETAINED_SNAPSHOTS } = await import(
+      "../constants.js"
+    );
+
+    const realNow = Date.now;
+    let clock = realNow.call(Date);
+    Date.now = () => clock;
+
+    try {
+      const total = MAX_RETAINED_SNAPSHOTS + 20;
+      for (let i = 0; i < total; i++) {
+        meter.handleEvent(textDelta(`ses_${i}`, "streaming output here", `msg_${i}`));
+        clock += 20;
+        meter.handleEvent(textDelta(`ses_${i}`, " more output", `msg_${i}`));
+      }
+      expect(meter.getSnapshots().size).toBe(total);
+
+      clock += MAX_MESSAGE_AGE_MS + CLEANUP_INTERVAL_MS + 1;
+      meter.handleEvent(textDelta("ses_trigger", "sweep now", "msg_t"));
+
+      expect(meter.getSnapshots().size).toBeLessThanOrEqual(MAX_RETAINED_SNAPSHOTS + 1);
+      // The most recent sessions survive; the oldest are evicted first.
+      expect(meter.getSnapshots().has(`ses_${total - 1}`)).toBe(true);
+      expect(meter.getSnapshots().has("ses_0")).toBe(false);
+    } finally {
+      Date.now = realNow;
+      meter.dispose();
+    }
+  });
+
+  it("ignores v1 event shapes and unrelated v2 events", async () => {
+    const { meter } = createHarness();
+
+    meter.handleEvent({
+      type: "message.part.delta",
+      properties: { sessionID: "ses_1", messageID: "msg_1", delta: "ignored" },
+    } as unknown as V2UnknownEvent);
+    meter.handleEvent({ type: "session.created", data: { sessionID: "ses_1" } });
+    meter.handleEvent({ type: "session.text.delta" } as V2UnknownEvent);
+
+    await delay(40);
+
+    expect(meter.getSnapshots().size).toBe(0);
+
+    meter.dispose();
+  });
+
+  it("notifies subscribers and stops after unsubscribe", async () => {
+    const { meter } = createHarness();
+    const seen: number[] = [];
+
+    const unsubscribe = meter.subscribe((snapshots) => seen.push(snapshots.size));
+
+    meter.handleEvent(textDelta("ses_1", "streaming for subscribers"));
+    await delay(40);
+    expect(seen.length).toBeGreaterThan(0);
+
+    const countAfterFirst = seen.length;
+    unsubscribe();
+
+    meter.handleEvent(textDelta("ses_1", "more streaming"));
+    await delay(80);
+    expect(seen.length).toBe(countAfterFirst);
+
+    meter.dispose();
+  });
+
+  it("clears state and pending timers on dispose", async () => {
+    const { meter } = createHarness();
+
+    meter.handleEvent(textDelta("ses_1", "streaming then disposed"));
+    meter.dispose();
+
+    await delay(40);
+
+    expect(meter.getSnapshots().size).toBe(0);
+  });
+});
+
+describe("v2 plugin entries", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      originalEnv.set(key, process.env[key]);
+      process.env[key] = stableEnv[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      const previous = originalEnv.get(key);
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+    originalEnv.clear();
+  });
+
+  it("registers the TUI meter on prompt.footer.status and tears down on cleanup", async () => {
+    const { ensureSolidTransformPlugin } = await import("@opentui/solid/bun-plugin");
+    ensureSolidTransformPlugin();
+
+    const { setupTui } = await import("../v2/tui.js");
+    const { RGBA } = await import("@opentui/core");
+
+    const color = RGBA.fromInts(255, 255, 255, 255);
+    const handlers = new Map<string, (event: unknown) => void>();
+    const removedHandlers: string[] = [];
+    const claims: Array<Record<string, unknown>> = [];
+    let slotDisposed = false;
+
+    const theme = {
+      text: {
+        default: color,
+        subdued: color,
+        feedback: {
+          error: { default: color },
+          warning: { default: color },
+          success: { default: color },
+          info: { default: color },
+        },
+      },
+    };
+
+    const cleanup = setupTui({
+      options: undefined,
+      theme,
+      data: {
+        on: (type: string, handler: (event: never) => void) => {
+          handlers.set(type, handler as (event: unknown) => void);
+          return () => {
+            removedHandlers.push(type);
+            handlers.delete(type);
+          };
+        },
+      },
+      ui: {
+        slot: (claim: Record<string, unknown>) => {
+          claims.push(claim);
+          return () => {
+            slotDisposed = true;
+          };
+        },
+      },
+    } as never);
+
+    expect(claims).toHaveLength(1);
+    expect(claims[0]?.append).toBe("prompt.footer.status");
+    expect(typeof claims[0]?.render).toBe("function");
+
+    // The v2 events that replace v1's message.* family, plus the step/tool/execution
+    // events Tier 2 needs for attribution and turn decomposition.
+    expect([...handlers.keys()].sort()).toEqual([
+      "session.execution.failed",
+      "session.execution.interrupted",
+      "session.execution.started",
+      "session.execution.succeeded",
+      "session.idle",
+      "session.reasoning.delta",
+      "session.step.ended",
+      "session.step.started",
+      "session.text.delta",
+      "session.tool.called",
+      "session.tool.failed",
+      "session.tool.success",
+      "session.usage.updated",
+    ]);
+
+    expect(typeof cleanup).toBe("function");
+    await (cleanup as () => void | Promise<void>)();
+
+    expect(slotDisposed).toBe(true);
+    expect(removedHandlers.sort()).toEqual([
+      "session.execution.failed",
+      "session.execution.interrupted",
+      "session.execution.started",
+      "session.execution.succeeded",
+      "session.idle",
+      "session.reasoning.delta",
+      "session.step.ended",
+      "session.step.started",
+      "session.text.delta",
+      "session.tool.called",
+      "session.tool.failed",
+      "session.tool.success",
+      "session.usage.updated",
+    ]);
+  });
+
+  it("does not register anything when disabled", async () => {
+    process.env.TPS_METER_ENABLED = "false";
+
+    const { ensureSolidTransformPlugin } = await import("@opentui/solid/bun-plugin");
+    ensureSolidTransformPlugin();
+    const { setupTui } = await import("../v2/tui.js");
+
+    let slotCalls = 0;
+    const cleanup = setupTui({
+      options: undefined,
+      theme: { text: { default: null, subdued: null, feedback: {} } },
+      data: { on: () => () => {} },
+      ui: {
+        slot: () => {
+          slotCalls += 1;
+          return () => {};
+        },
+      },
+    } as never);
+
+    expect(slotCalls).toBe(0);
+    expect(cleanup).toBeUndefined();
+  });
+
+  it("drains the server event stream and stops on cleanup", async () => {
+    const { setupServer, getSnapshots } = await import("../v2/server.js");
+
+    let aborted = false;
+    const events: V2UnknownEvent[] = [
+      textDelta("ses_srv", "streaming through the server plugin"),
+    ];
+
+    const cleanup = setupServer({
+      options: undefined,
+      event: {
+        subscribe: ({ signal }: { signal?: AbortSignal } = {}) => ({
+          async *[Symbol.asyncIterator]() {
+            for (const event of events) {
+              yield event;
+            }
+            // Stay open until aborted, mirroring the real long-lived stream.
+            await new Promise<void>((resolve) => {
+              if (!signal) {
+                resolve();
+                return;
+              }
+              signal.addEventListener("abort", () => {
+                aborted = true;
+                resolve();
+              });
+            });
+          },
+        }),
+      },
+    } as never);
+
+    await delay(40);
+
+    expect(getSnapshots().get("ses_srv")?.totalTokens).toBeGreaterThan(0);
+
+    expect(typeof cleanup).toBe("function");
+    await (cleanup as () => void | Promise<void>)();
+    await delay(10);
+
+    expect(aborted).toBe(true);
+    expect(getSnapshots().size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2: attribution, turn decomposition, tokenizer calibration
+// ---------------------------------------------------------------------------
+
+function at(base: number, offset: number): number {
+  return base + offset;
+}
+
+function evt(type: string, created: number, data: Record<string, unknown>): V2UnknownEvent {
+  eventId += 1;
+  return { id: `evt_${eventId}`, created, type, data };
+}
+
+const textAt = (s: string, delta: string, created: number, msg = "msg_1") =>
+  evt("session.text.delta", created, {
+    sessionID: s,
+    assistantMessageID: msg,
+    ordinal: 0,
+    delta,
+  });
+
+describe("v2 metrics", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      originalEnv.set(key, process.env[key]);
+      process.env[key] = stableEnv[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      const previous = originalEnv.get(key);
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+    originalEnv.clear();
+  });
+
+  function harness() {
+    const meter = createMeter(loadConfigSync());
+    return { meter, snap: (id: string) => meter.getSnapshots().get(id) };
+  }
+
+  it("measures time to first token from the host-stamped turn start", () => {
+    const { meter, snap } = harness();
+    const base = Date.now();
+
+    meter.handleEvent(evt("session.execution.started", at(base, 0), { sessionID: "s" }));
+    meter.handleEvent(textAt("s", "first chunk of output", at(base, 250)));
+    meter.handleEvent(textAt("s", " and more output here", at(base, 300)));
+
+    expect(snap("s")?.ttftMs).toBe(250);
+    meter.dispose();
+  });
+
+  it("excludes tool execution time from generationTps", () => {
+    const { meter, snap } = harness();
+    const base = Date.now();
+
+    meter.handleEvent(evt("session.execution.started", at(base, 0), { sessionID: "s" }));
+    meter.handleEvent(textAt("s", "abcdefghijklmnopqrstuvwxyz01", at(base, 100)));
+    // A tool runs for 2s in the middle of the turn.
+    meter.handleEvent(evt("session.tool.called", at(base, 200), { sessionID: "s", id: "c1" }));
+    meter.handleEvent(evt("session.tool.success", at(base, 2200), { sessionID: "s", id: "c1" }));
+    meter.handleEvent(textAt("s", "abcdefghijklmnopqrstuvwxyz02", at(base, 2300)));
+
+    const s = snap("s");
+    expect(s?.toolMs).toBe(2000);
+    // Dead time removed, so the model's own rate is strictly higher than end-to-end.
+    expect(s?.generationTps).toBeGreaterThan(s?.avgTps ?? 0);
+    meter.dispose();
+  });
+
+  it("attributes throughput to the model and agent from session.step.started", () => {
+    const { meter, snap } = harness();
+    const base = Date.now();
+
+    meter.handleEvent(
+      evt("session.step.started", at(base, 0), {
+        sessionID: "s",
+        assistantMessageID: "msg_1",
+        agent: "build",
+        model: { id: "qwen3.8-max", providerID: "tokenrouter", variant: "max" },
+      })
+    );
+    meter.handleEvent(textAt("s", "some streamed output", at(base, 10)));
+    meter.handleEvent(textAt("s", " continuing onwards", at(base, 60)));
+
+    expect(snap("s")?.modelKey).toBe("tokenrouter/qwen3.8-max#max");
+    expect(snap("s")?.agent).toBe("build");
+    meter.dispose();
+  });
+
+  it("calibrates the live estimate against provider ground truth", () => {
+    const { meter, snap } = harness();
+    const base = Date.now();
+    const model = { id: "m", providerID: "p" };
+    const forty = "0123456789012345678901234567890123456789"; // 40 chars -> 10 heuristic
+
+    // Step 1 establishes the factor: 20 real tokens for 10 heuristic => 2.0
+    meter.handleEvent(
+      evt("session.step.started", at(base, 0), { sessionID: "s", assistantMessageID: "m1", model })
+    );
+    meter.handleEvent(textAt("s", forty, at(base, 10), "m1"));
+    expect(snap("s")?.calibrationSamples ?? 0).toBe(0); // not yet calibrated
+    meter.handleEvent(
+      evt("session.step.ended", at(base, 100), {
+        sessionID: "s",
+        assistantMessageID: "m1",
+        finish: "stop",
+        cost: 0,
+        tokens: { input: 0, output: 20, reasoning: 0, cache: { read: 0, write: 0 } },
+      })
+    );
+
+    // Step 2 streams the same text and should now count ~2x.
+    meter.handleEvent(
+      evt("session.step.started", at(base, 200), { sessionID: "s", assistantMessageID: "m2", model })
+    );
+    meter.handleEvent(textAt("s", forty, at(base, 210), "m2"));
+    meter.handleEvent(textAt("s", forty, at(base, 260), "m2"));
+
+    const s = snap("s");
+    expect(s?.calibrationSamples).toBe(1);
+    expect(s?.totalTokens).toBe(40); // 20 heuristic * factor 2
+    meter.dispose();
+  });
+
+  it("ignores calibration samples outside the trusted band", () => {
+    const { meter, snap } = harness();
+    const base = Date.now();
+    const model = { id: "m", providerID: "p" };
+    const forty = "0123456789012345678901234567890123456789";
+
+    meter.handleEvent(
+      evt("session.step.started", at(base, 0), { sessionID: "s", assistantMessageID: "m1", model })
+    );
+    meter.handleEvent(textAt("s", forty, at(base, 10), "m1"));
+    // 10 heuristic vs 5000 real => factor 500, far outside the band: reject, stay at 1.0
+    meter.handleEvent(
+      evt("session.step.ended", at(base, 100), {
+        sessionID: "s",
+        assistantMessageID: "m1",
+        finish: "stop",
+        cost: 0,
+        tokens: { input: 0, output: 5000, reasoning: 0, cache: { read: 0, write: 0 } },
+      })
+    );
+
+    meter.handleEvent(
+      evt("session.step.started", at(base, 200), { sessionID: "s", assistantMessageID: "m2", model })
+    );
+    meter.handleEvent(textAt("s", forty, at(base, 210), "m2"));
+    meter.handleEvent(textAt("s", forty, at(base, 260), "m2"));
+
+    expect(snap("s")?.calibrationSamples).toBe(0);
+    expect(snap("s")?.totalTokens).toBe(20); // uncalibrated
+    meter.dispose();
+  });
+
+  it("marks an interrupted turn as untrustworthy", async () => {
+    const { meter, snap } = harness();
+    const base = Date.now();
+
+    meter.handleEvent(evt("session.execution.started", at(base, 0), { sessionID: "s" }));
+    meter.handleEvent(textAt("s", "partial output before abort", at(base, 20)));
+    meter.handleEvent(textAt("s", " more partial output", at(base, 80)));
+    meter.handleEvent(
+      evt("session.execution.interrupted", at(base, 120), { sessionID: "s", reason: "user" })
+    );
+    meter.handleEvent(textAt("s", " trailing", at(base, 180)));
+    // The publish throttle is wall-clock, so let the scheduled update land.
+    await delay(40);
+
+    expect(snap("s")?.interrupted).toBe(true);
+    meter.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Durable ledger + the Tier 2/3 surfaces
+// ---------------------------------------------------------------------------
+
+describe("v2 ledger", () => {
+  it("rolls up measurements per model and computes mean throughput", async () => {
+    const { createLedger } = await import("../v2/ledger.js");
+    const ledger = createLedger();
+
+    ledger.record({ modelKey: "p/m", tokens: 100, generationMs: 1000, cost: 0.01, ttftMs: 200 });
+    ledger.record({ modelKey: "p/m", tokens: 300, generationMs: 1000, cost: 0.02, ttftMs: 400 });
+
+    const entry = ledger.read().models["p/m"];
+    expect(entry?.samples).toBe(2);
+    expect(entry?.tokens).toBe(400);
+    expect(ledger.meanTps("p/m")).toBe(200); // 400 tokens over 2s
+    expect(entry?.bestTps).toBe(300);
+    expect(entry?.meanTtftMs).toBe(300);
+    expect(entry?.cost).toBeCloseTo(0.03, 5);
+  });
+
+  it("rejects measurements that cannot yield a rate", async () => {
+    const { createLedger } = await import("../v2/ledger.js");
+    const ledger = createLedger();
+
+    ledger.record({ modelKey: "p/m", tokens: 0, generationMs: 1000, cost: 0, ttftMs: 0 });
+    ledger.record({ modelKey: "p/m", tokens: 100, generationMs: 0, cost: 0, ttftMs: 0 });
+    ledger.record({ modelKey: "", tokens: 100, generationMs: 100, cost: 0, ttftMs: 0 });
+
+    expect(Object.keys(ledger.read().models)).toHaveLength(0);
+  });
+
+  it("writes through the host store when one is provided", async () => {
+    const { createLedger } = await import("../v2/ledger.js");
+    let state: Record<string, unknown> = { version: 1, models: {} };
+    const storage = {
+      store: () =>
+        [
+          state,
+          (mutation: (draft: Record<string, unknown>) => void) => {
+            const draft = JSON.parse(JSON.stringify(state));
+            mutation(draft);
+            state = draft;
+            return Promise.resolve();
+          },
+        ] as never,
+      memory: () => [{}, () => {}] as never,
+    };
+
+    const ledger = createLedger(storage as never);
+    ledger.record({ modelKey: "p/m", tokens: 50, generationMs: 500, cost: 0, ttftMs: 0 });
+
+    // The mutation landed in the host-owned object, not a private copy.
+    expect((state.models as Record<string, { samples: number }>)["p/m"]?.samples).toBe(1);
+  });
+});
+
+describe("v2 optional surfaces", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      originalEnv.set(key, process.env[key]);
+      process.env[key] = stableEnv[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      const previous = originalEnv.get(key);
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+    originalEnv.clear();
+  });
+
+  it("registers the sidebar panel, dashboard route and commands when the host offers them", async () => {
+    const { ensureSolidTransformPlugin } = await import("@opentui/solid/bun-plugin");
+    ensureSolidTransformPlugin();
+    const { setupTui } = await import("../v2/tui.js");
+    const { RGBA } = await import("@opentui/core");
+    const color = RGBA.fromInts(255, 255, 255, 255);
+
+    const claims: Array<Record<string, unknown>> = [];
+    const routes: Array<Record<string, unknown>> = [];
+    let layers = 0;
+
+    const cleanup = setupTui({
+      options: undefined,
+      theme: {
+        text: {
+          default: color,
+          subdued: color,
+          feedback: {
+            error: { default: color },
+            warning: { default: color },
+            success: { default: color },
+            info: { default: color },
+          },
+        },
+      },
+      data: {
+        on: () => () => {},
+        session: {
+          get: () => ({ agent: "build" }),
+          root: (id: string) => id,
+          family: (id: string) => [id],
+          cost: () => 0,
+          status: () => "idle",
+        },
+      },
+      ui: {
+        slot: (claim: Record<string, unknown>) => {
+          claims.push(claim);
+          return () => {};
+        },
+        toast: { show: () => {} },
+        router: {
+          register: (page: Record<string, unknown>) => {
+            routes.push(page);
+            return () => {};
+          },
+          navigate: () => {},
+          current: () => ({ type: "home" }),
+        },
+      },
+      keymap: {
+        layer: () => {
+          layers += 1;
+        },
+      },
+      storage: {
+        store: () => [{ version: 1, models: {} }, () => Promise.resolve()] as never,
+        memory: () => [{}, () => {}] as never,
+      },
+    } as never);
+
+    const targets = claims.map((c) => c.append).sort();
+    expect(targets).toEqual(["app", "prompt.footer.status", "sidebar.content"]);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.name).toBe("tps");
+
+    expect(typeof cleanup).toBe("function");
+    await (cleanup as () => void | Promise<void>)();
+  });
+
+  it("degrades to the footer meter alone when the host offers nothing optional", async () => {
+    const { ensureSolidTransformPlugin } = await import("@opentui/solid/bun-plugin");
+    ensureSolidTransformPlugin();
+    const { setupTui } = await import("../v2/tui.js");
+    const { RGBA } = await import("@opentui/core");
+    const color = RGBA.fromInts(255, 255, 255, 255);
+
+    const claims: Array<Record<string, unknown>> = [];
+    const cleanup = setupTui({
+      options: undefined,
+      theme: {
+        text: {
+          default: color,
+          subdued: color,
+          feedback: {
+            error: { default: color },
+            warning: { default: color },
+            success: { default: color },
+            info: { default: color },
+          },
+        },
+      },
+      data: { on: () => () => {} },
+      ui: {
+        slot: (claim: Record<string, unknown>) => {
+          claims.push(claim);
+          return () => {};
+        },
+      },
+    } as never);
+
+    expect(claims.map((c) => c.append)).toEqual(["prompt.footer.status"]);
+    await (cleanup as () => void | Promise<void>)();
+  });
+});
+
+describe("v2 server wire timings", () => {
+  it("measures request-dispatch to response-headers latency", async () => {
+    const { setupServer, getWireTimings } = await import("../v2/server.js");
+
+    const hooks = new Map<string, (input: Record<string, unknown>) => void>();
+    const cleanup = setupServer({
+      options: undefined,
+      event: {
+        subscribe: () => ({
+          async *[Symbol.asyncIterator]() {
+            // no events; this test only exercises the HTTP hooks
+          },
+        }),
+      },
+      session: {
+        hook: (name: string, cb: (input: Record<string, unknown>) => void) => {
+          hooks.set(name, cb);
+        },
+      },
+    } as never);
+
+    expect([...hooks.keys()].sort()).toEqual(["http.request", "http.response"]);
+
+    hooks.get("http.request")?.({ sessionID: "s", providerID: "p" });
+    await delay(30);
+    hooks.get("http.response")?.({ sessionID: "s", providerID: "p" });
+
+    const timing = getWireTimings().get("s");
+    expect(timing?.samples).toBe(1);
+    expect(timing?.providerID).toBe("p");
+    expect(timing?.ttfbMs ?? 0).toBeGreaterThanOrEqual(20);
+
+    await (cleanup as () => void | Promise<void>)();
+    expect(getWireTimings().size).toBe(0);
+  });
+
+  it("survives a host that exposes no session hooks", async () => {
+    const { setupServer } = await import("../v2/server.js");
+    const cleanup = setupServer({
+      options: undefined,
+      event: {
+        subscribe: () => ({
+          async *[Symbol.asyncIterator]() {},
+        }),
+      },
+    } as never);
+    expect(typeof cleanup).toBe("function");
+    await (cleanup as () => void | Promise<void>)();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Incremental counting must be numerically identical to batch counting
+// ---------------------------------------------------------------------------
+
+describe("incremental token counting", () => {
+  it("matches the batch counter for every algorithm and chunking", async () => {
+    const { createTokenizer, createIncrementalCounter } = await import("../tokenCounter.js");
+
+    const corpora = [
+      "the quick brown fox jumps over the lazy dog",
+      "  leading and trailing whitespace   ",
+      "no-spaces-at-all-just-one-long-token",
+      "multiple   consecutive    spaces\tand\ttabs\nand\nnewlines",
+      "a b c d e f g h i j k l m n o p",
+      "",
+      "x",
+      "trailing space ",
+      " leading space",
+    ];
+    const chunkSizes = [1, 2, 3, 5, 7, 100];
+
+    for (const algorithm of ["heuristic", "word", "code"] as const) {
+      const batch = createTokenizer(algorithm);
+      for (const text of corpora) {
+        for (const size of chunkSizes) {
+          const counter = createIncrementalCounter(algorithm);
+          let sum = 0;
+          for (let i = 0; i < text.length; i += size) {
+            sum += counter.add(text.slice(i, i + size));
+          }
+          expect({ algorithm, size, text, sum }).toEqual({
+            algorithm,
+            size,
+            text,
+            sum: batch.count(text),
+          });
+          expect(counter.total()).toBe(batch.count(text));
+        }
+      }
+    }
+  });
+
+  it("joins words split across chunk boundaries", async () => {
+    const { createIncrementalCounter, createTokenizer } = await import("../tokenCounter.js");
+    const counter = createIncrementalCounter("word");
+    // "fo" + "x" is ONE word, not two.
+    counter.add("fo");
+    counter.add("x");
+    counter.add(" bar");
+    expect(counter.total()).toBe(createTokenizer("word").count("fox bar"));
+  });
+
+  it("absorbs a long stream in linear time", async () => {
+    const { createIncrementalCounter } = await import("../tokenCounter.js");
+    const chunk = "the quick brown fox jumps over ";
+
+    const time = (deltas: number): number => {
+      const counter = createIncrementalCounter("word");
+      const t0 = performance.now();
+      for (let i = 0; i < deltas; i++) counter.add(chunk);
+      return performance.now() - t0;
+    };
+
+    time(2000); // warm up
+    const small = Math.max(time(2000), 0.5);
+    const large = Math.max(time(8000), 0.5);
+    // Quadratic would be ~16x for 4x the input; linear is ~4x. Allow generous headroom
+    // for a noisy CI machine while still failing loudly on a return to O(n^2).
+    expect(large / small).toBeLessThan(10);
+  });
+});
+
+describe("smoothing latency", () => {
+  it("leaves the v1 tracker default untouched", async () => {
+    const { createTracker } = await import("../tracker.js");
+    const { DEFAULT_EWMA_HALF_LIFE_MS } = await import("../constants.js");
+
+    const base = 1_000_000;
+    const feed = (t: { recordTokens: (n: number, ts: number) => void }) => {
+      for (let i = 1; i <= 40; i++) t.recordTokens(1, base + i * 10);
+    };
+
+    const implicit = createTracker({});
+    const explicit = createTracker({ ewmaHalfLifeMs: DEFAULT_EWMA_HALF_LIFE_MS });
+    feed(implicit);
+    feed(explicit);
+
+    // Omitting the option must behave exactly like passing the v1 constant.
+    expect(implicit.getSmoothedTPS()).toBeCloseTo(explicit.getSmoothedTPS(), 6);
+  });
+
+  it("converges faster with the v2 half-life", async () => {
+    const { createTracker } = await import("../tracker.js");
+    const { DEFAULT_EWMA_HALF_LIFE_MS, V2_EWMA_HALF_LIFE_MS } = await import("../constants.js");
+
+    expect(V2_EWMA_HALF_LIFE_MS).toBeLessThan(DEFAULT_EWMA_HALF_LIFE_MS);
+
+    const converge = (halfLife: number): number => {
+      const t = createTracker({ rollingWindowMs: 1000, ewmaHalfLifeMs: halfLife });
+      const base = 1_000_000;
+      for (let i = 1; i <= 600; i++) {
+        t.recordTokens(0.9, base + i * 10); // steady 90 TPS
+        if (t.getSmoothedTPS() >= 81) return i * 10;
+      }
+      return Number.POSITIVE_INFINITY;
+    };
+
+    const v1 = converge(DEFAULT_EWMA_HALF_LIFE_MS);
+    const v2 = converge(V2_EWMA_HALF_LIFE_MS);
+    expect(v2).toBeLessThan(v1);
+  });
+});
+
+describe("publish latency", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      originalEnv.set(key, process.env[key]);
+      process.env[key] = stableEnv[key];
+    }
+    // Exercise the shipped default rather than the test override.
+    delete process.env.TPS_METER_UPDATE_INTERVAL_MS;
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      const previous = originalEnv.get(key);
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+    originalEnv.clear();
+  });
+
+  it("shows nearly every delta instead of dropping updates", async () => {
+    const meter = createMeter(loadConfigSync());
+    let updates = 0;
+    meter.subscribe(() => {
+      updates += 1;
+    });
+
+    const base = Date.now();
+    const DELTAS = 40;
+    for (let i = 0; i < DELTAS; i++) {
+      meter.handleEvent({
+        id: `e${i}`,
+        created: base + i * 10,
+        type: "session.text.delta",
+        data: { sessionID: "s", assistantMessageID: "m", ordinal: 0, delta: "streamed text " },
+      } as unknown as V2UnknownEvent);
+      await delay(10);
+    }
+    await delay(40);
+    meter.dispose();
+
+    // Before the wall-clock fix this produced roughly one update per 15 deltas, because a
+    // scheduled publish that failed its guard was dropped and never rescheduled.
+    expect(updates).toBeGreaterThan(DELTAS * 0.8);
+  });
+
+  it("publishes synchronously once the throttle window is open", async () => {
+    const meter = createMeter(loadConfigSync());
+    let updates = 0;
+    meter.subscribe(() => {
+      updates += 1;
+    });
+
+    const base = Date.now();
+    meter.handleEvent({
+      id: "warm",
+      created: base,
+      type: "session.text.delta",
+      data: { sessionID: "s", assistantMessageID: "m", ordinal: 0, delta: "warm up text" },
+    } as unknown as V2UnknownEvent);
+    await delay(40);
+
+    const before = updates;
+    meter.handleEvent({
+      id: "next",
+      created: Date.now(),
+      type: "session.text.delta",
+      data: { sessionID: "s", assistantMessageID: "m", ordinal: 0, delta: "another chunk" },
+    } as unknown as V2UnknownEvent);
+
+    // No await: the update must already be visible.
+    expect(updates).toBeGreaterThan(before);
+    meter.dispose();
+  });
+});
+
+describe("v2 resilience", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      originalEnv.set(key, process.env[key]);
+      process.env[key] = stableEnv[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(stableEnv) as Array<keyof typeof stableEnv>) {
+      const previous = originalEnv.get(key);
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+    originalEnv.clear();
+  });
+
+  it("still renders the footer meter when every optional host API throws", async () => {
+    const { ensureSolidTransformPlugin } = await import("@opentui/solid/bun-plugin");
+    ensureSolidTransformPlugin();
+    const { setupTui } = await import("../v2/tui.js");
+    const { RGBA } = await import("@opentui/core");
+    const color = RGBA.fromInts(255, 255, 255, 255);
+
+    const claims: Array<Record<string, unknown>> = [];
+    const boom = () => {
+      throw new Error("host API mismatch");
+    };
+
+    // Every optional surface is present but broken — exactly the shape of a beta API drift.
+    // Before this was guarded, a single throw aborted setup and the host reported a failed
+    // plugin load, leaving the user with no meter and nothing in the log.
+    const cleanup = setupTui({
+      options: undefined,
+      theme: {
+        text: {
+          default: color,
+          subdued: color,
+          feedback: {
+            error: { default: color },
+            warning: { default: color },
+            success: { default: color },
+            info: { default: color },
+          },
+        },
+      },
+      data: {
+        on: () => () => {},
+        session: { get: boom, root: boom, family: boom, cost: boom, status: boom },
+      },
+      ui: {
+        slot: (claim: Record<string, unknown>) => {
+          claims.push(claim);
+          if (claim.append !== "prompt.footer.status") boom();
+          return () => {};
+        },
+        toast: { show: boom },
+        router: { register: boom, navigate: boom, current: boom },
+      },
+      keymap: { layer: boom },
+      storage: { store: boom, memory: boom },
+    } as never);
+
+    // The one surface that must survive.
+    expect(claims.some((c) => c.append === "prompt.footer.status")).toBe(true);
+    expect(typeof cleanup).toBe("function");
+    await (cleanup as () => void | Promise<void>)();
+  });
+
+  it("keeps metering when the durable store rejects writes", async () => {
+    const { createLedger } = await import("../v2/ledger.js");
+    const ledger = createLedger({
+      store: () =>
+        [
+          { version: 1, models: {} },
+          () => {
+            throw new Error("store is read-only");
+          },
+        ] as never,
+      memory: () => [{}, () => {}] as never,
+    } as never);
+
+    // Must not throw, and must fall back to the in-memory rollup.
+    ledger.record({ modelKey: "p/m", tokens: 100, generationMs: 1000, cost: 0, ttftMs: 0 });
+    ledger.record({ modelKey: "p/m", tokens: 100, generationMs: 1000, cost: 0, ttftMs: 0 });
+    expect(ledger.meanTps("p/m")).toBeGreaterThan(0);
+  });
+});
+
+describe("build invariants", () => {
+  it("keeps @opentui out of the root bundle's static imports", async () => {
+    // Loading @opentui/solid inside the SERVER process dies with
+    // `Environment variable "OPENTUI_FORCE_WCWIDTH" is already registered`, which fails the
+    // plugin load outright. dist/index.mjs is loaded by both the service and (via the
+    // dual-host shape) the TUI, so the TUI half must stay behind a runtime import.
+    const fs = await import("node:fs/promises");
+    const bundle = await fs.readFile("dist/index.mjs", "utf8");
+
+    const staticImports = bundle
+      .split("\n")
+      .filter((line) => /^import[\s{*]/.test(line))
+      .filter((line) => /@opentui|solid-js/.test(line));
+
+    expect(staticImports).toEqual([]);
+    // ...and the lazy path must still be there.
+    expect(bundle.includes("./tui.mjs")).toBe(true);
+  });
+
+  it("ships only dist and docs", async () => {
+    const pkg = await import("../../package.json");
+    expect(pkg.default.files).toEqual(["dist", "README.md", "LICENSE"]);
+    // Runtime deps would be bundled into the host; the renderer must come from the host.
+    expect(pkg.default.dependencies).toBeUndefined();
+  });
+});

--- a/src/__tests__/v2.test.ts
+++ b/src/__tests__/v2.test.ts
@@ -576,7 +576,9 @@ describe("v2 plugin entries", () => {
     } as never);
 
     expect(claims).toHaveLength(1);
-    expect(claims[0]?.append).toBe("prompt.footer.status");
+    // Must PREPEND: the host's own flexGrow:1 child would squeeze an appended
+    // meter to zero width whenever a turn is running.
+    expect(claims[0]?.prepend).toBe("prompt.footer.status");
     expect(typeof claims[0]?.render).toBe("function");
 
     // The v2 events that replace v1's message.* family, plus the step/tool/execution
@@ -1001,7 +1003,7 @@ describe("v2 optional surfaces", () => {
       },
     } as never);
 
-    const targets = claims.map((c) => c.append).sort();
+    const targets = claims.map((c) => c.append ?? c.prepend).sort();
     expect(targets).toEqual(["app", "prompt.footer.status", "sidebar.content"]);
     expect(routes).toHaveLength(1);
     expect(routes[0]?.name).toBe("tps");
@@ -1041,7 +1043,7 @@ describe("v2 optional surfaces", () => {
       },
     } as never);
 
-    expect(claims.map((c) => c.append)).toEqual(["prompt.footer.status"]);
+    expect(claims.map((c) => c.append ?? c.prepend)).toEqual(["prompt.footer.status"]);
     await (cleanup as () => void | Promise<void>)();
   });
 });
@@ -1338,7 +1340,7 @@ describe("v2 resilience", () => {
       ui: {
         slot: (claim: Record<string, unknown>) => {
           claims.push(claim);
-          if (claim.append !== "prompt.footer.status") boom();
+          if (claim.prepend !== "prompt.footer.status") boom();
           return () => {};
         },
         toast: { show: boom },
@@ -1349,7 +1351,7 @@ describe("v2 resilience", () => {
     } as never);
 
     // The one surface that must survive.
-    expect(claims.some((c) => c.append === "prompt.footer.status")).toBe(true);
+    expect(claims.some((c) => c.prepend === "prompt.footer.status")).toBe(true);
     expect(typeof cleanup).toBe("function");
     await (cleanup as () => void | Promise<void>)();
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -304,6 +304,7 @@ function loadEnvConfig(): Partial<Config> {
  * 1. .opencode/tps-meter.json (project-level)
  * 2. ~/.config/opencode/tps-meter.json (global)
  * 3. Environment variables (TPS_METER_*)
+ * 4. Inline overrides (v2 plugin `options`)
  *
  * Later sources override earlier ones.
  *
@@ -315,7 +316,7 @@ function loadEnvConfig(): Partial<Config> {
  *   // Initialize plugin
  * }
  */
-export function loadConfigSync(): Config {
+export function loadConfigSync(overrides?: Partial<Config>): Config {
   let mergedConfig: Partial<Config> = {};
 
   // Priority 1: Project-level config (.opencode/tps-meter.json)
@@ -345,6 +346,12 @@ export function loadConfigSync(): Config {
   // Priority 3: Environment variables (override config files)
   const envConfig = loadEnvConfig();
   mergedConfig = { ...mergedConfig, ...envConfig };
+
+  // Priority 4: Inline overrides. On v2 these are the plugin's `options` from
+  // opencode.json; v1 has no equivalent and passes nothing.
+  if (overrides) {
+    mergedConfig = { ...mergedConfig, ...overrides };
+  }
 
   // Merge with defaults and return
   return mergeConfig(mergedConfig, defaultConfig);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,15 @@ export const BURST_TOKEN_THRESHOLD = 50;
 /** Default EWMA half-life (ms) for smoothing normal streaming */
 export const DEFAULT_EWMA_HALF_LIFE_MS = 250;
 
+/**
+ * EWMA half-life (ms) for normal streaming on v2.
+ *
+ * Lower than the v1 default: v2 timestamps tokens with the host clock rather than the
+ * event-flush clock, so the rolling window is already an accurate average and the extra
+ * exponential lag mostly just delays the reading.
+ */
+export const V2_EWMA_HALF_LIFE_MS = 120;
+
 /** EWMA half-life (ms) applied during medium bursts (50-200 tokens) */
 export const BURST_EWMA_HALF_LIFE_MS = 3000;
 
@@ -48,6 +57,15 @@ export const MAX_INITIAL_TPS = 100;
 /** Default UI update interval in milliseconds */
 export const DEFAULT_UPDATE_INTERVAL_MS = 50;
 
+/**
+ * Display throttle for the v2 TUI meter (ms).
+ *
+ * The host flushes events in ~10ms batches, so this is the point past which publishing more
+ * often cannot reveal anything new. Updating a slot's text is far cheaper than the v1 toast
+ * path, which is why v1 keeps a larger default.
+ */
+export const V2_UPDATE_INTERVAL_MS = 8;
+
 /** Minimum interval between toast updates (ms) - prevents UI flooding */
 export const MIN_TOAST_INTERVAL_MS = 80;
 
@@ -63,6 +81,15 @@ export const FINAL_STATS_DURATION_MS = 2000;
 
 /** Maximum age of message entries before cleanup (5 minutes in ms) */
 export const MAX_MESSAGE_AGE_MS = 5 * 60 * 1000;
+
+/**
+ * Maximum frozen readings retained after their session state has been swept.
+ *
+ * A swept session keeps its last reading so the meter does not blank out — v1 kept readings
+ * indefinitely, and erasing one reads as the meter "forgetting". The reading is a handful of
+ * numbers, so retaining many is cheap; this only bounds pathological session churn.
+ */
+export const MAX_RETAINED_SNAPSHOTS = 64;
 
 /** Interval between stale message cleanup runs (30 seconds in ms) */
 export const CLEANUP_INTERVAL_MS = 30000;

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared meter text formatting.
+ *
+ * Used by both the v1 and v2 TUI entry points so the two hosts render identical text.
+ *
+ * @module format
+ */
+
+import type { Config } from "./types.js";
+
+/** Minimum shape needed to render a meter reading, satisfied by v1 and v2 snapshots alike. */
+export interface MeterReading {
+  instantTps: number;
+  avgTps: number;
+  totalTokens: number;
+  elapsedMs: number;
+  /** True while tokens are actively streaming. */
+  active: boolean;
+}
+
+/** Formats a token count with thousands separators. */
+export function formatNumber(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+/** Formats milliseconds as MM:SS. */
+export function formatElapsedTime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Renders the meter line.
+ *
+ * While streaming, the leading figure is the rolling instantaneous rate; once the turn
+ * settles it becomes the average, so a frozen meter reads as a summary rather than a
+ * stale live value.
+ */
+export function formatMeterText(reading: MeterReading, config: Config): string {
+  const parts: string[] = [];
+  const displayTps = reading.active ? reading.instantTps : reading.avgTps;
+
+  if (config.showInstant) {
+    parts.push(`${displayTps.toFixed(1)} TPS`);
+  }
+  if (config.showAverage) {
+    parts.push(`avg ${reading.avgTps.toFixed(1)}`);
+  }
+  if (config.showTotalTokens) {
+    parts.push(`${formatNumber(reading.totalTokens)} tok`);
+  }
+  if (config.showElapsed) {
+    parts.push(formatElapsedTime(reading.elapsedMs));
+  }
+
+  return parts.length > 0 ? parts.join(" · ") : "TPS meter";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,10 @@ import type {
 } from "./types.js";
 import { createTracker } from "./tracker.js";
 import { createUIManager } from "./ui.js";
-import { createTokenizer } from "./tokenCounter.js";
+import { createTokenizer, createIncrementalCounter, type IncrementalCounter } from "./tokenCounter.js";
 import { loadConfigSync, defaultConfig } from "./config.js";
+import { setupAuto as setupV2 } from "./v2/dispatch.js";
+import type { V2Cleanup, V2ServerContext, V2TuiContext } from "./v2/types.js";
 import {
   INVALID_FINISH_REASONS,
   COUNTABLE_PART_TYPES,
@@ -145,7 +147,7 @@ function extractPartText(part: Part): string {
  * @param {PluginContext} context - Plugin context from OpenCode framework
  * @returns {PluginHandlers | Record<string, never>} - Event handlers or empty object if disabled
  */
-export default function TpsMeterPlugin(
+function TpsMeterPlugin(
   context: PluginContext
 ): PluginHandlers | Record<string, never> {
   // Create safe logger fallback - handle missing context entirely
@@ -213,7 +215,18 @@ export default function TpsMeterPlugin(
   }
 
   const sessionTrackers = new Map<string, SessionTrackingState>();
-  const partTextCache = new Map<string, Map<string, string>>();
+  /**
+   * Per-part stream state.
+   *
+   * Part-type keys hold accumulated TEXT, because the `message.part.updated` path diffs a
+   * full part against what deltas already counted. The `:live` key instead holds an
+   * incremental counter: it was only ever read to compute a token difference, and doing that
+   * by re-counting the whole accumulated string is O(total) per delta — 1.6s of blocking work
+   * across a 62k-character response under the word heuristic.
+   *
+   * Both live in one map so the existing prefix-based cleanup collects them together.
+   */
+  const partTextCache = new Map<string, Map<string, string | IncrementalCounter>>();
   const messageTokenCache = new Map<string, Map<string, number>>();
   const messageRoleCache = new Map<
     string,
@@ -244,13 +257,13 @@ export default function TpsMeterPlugin(
   const ui = resolvedConfig.toastFallback
     ? createUIManager(safeContext.client || {}, resolvedConfig)
     : createNoopUIManager();
-  const tokenizer = createTokenizer(
+  const tokenizerAlgorithm =
     resolvedConfig.fallbackTokenHeuristic === "words_div_0_75"
       ? "word"
       : resolvedConfig.fallbackTokenHeuristic === "chars_div_3"
         ? "code"
-        : "heuristic"
-  );
+        : "heuristic";
+  const tokenizer = createTokenizer(tokenizerAlgorithm);
 
   logger.info("[TpsMeter] Plugin initialized and ready");
 
@@ -285,30 +298,6 @@ export default function TpsMeterPlugin(
     }
     if (stripped.length <= 6) return stripped;
     return `${stripped.slice(0, 6)}…`;
-  }
-
-  function buildAgentLabel(
-    messageId: string,
-    metadata?: TrackerMetadata
-  ): string {
-    // Priority for agent type: agent.type > agentType > agent.name > name
-    const typeLabel =
-      metadata?.agent?.type?.trim() ||
-      metadata?.agentType?.trim() ||
-      metadata?.agent?.name?.trim() ||
-      metadata?.name?.trim() ||
-      null;
-    
-    // Priority for ID: agentId > agent.id > messageId
-    const rawId =
-      metadata?.agentId?.trim() ||
-      metadata?.agent?.id?.trim() ||
-      messageId;
-    const identifier = abbreviateId(rawId);
-    
-    // Return full label if we have type, otherwise just identifier
-    // (getAllActiveAgentsGlobally will add agent name from cache if needed)
-    return typeLabel ? `${typeLabel}(${identifier})` : identifier;
   }
 
   /**
@@ -465,42 +454,6 @@ export default function TpsMeterPlugin(
     return false;
   }
 
-  function getActiveAgentDisplayStates(
-    sessionState: SessionTrackingState,
-    now: number
-  ): AgentDisplayState[] {
-    const activityWindow = Math.max(
-      resolvedConfig.rollingWindowMs,
-      resolvedConfig.initialDisplayDelayMs * 4
-    );
-    const entries: AgentDisplayState[] = [];
-
-    for (const trackerState of sessionState.messageTrackers.values()) {
-      if (!trackerState.firstTokenAt) {
-        continue;
-      }
-      if (now - trackerState.lastUpdated > activityWindow) {
-        continue;
-      }
-      // Only show subagents/background agents that have agent metadata
-      const hasAgentMetadata = Boolean(trackerState.agent || trackerState.agentId || trackerState.agentType);
-      if (!hasAgentMetadata) {
-        continue;
-      }
-      entries.push({
-        id: trackerState.messageId,
-        label: trackerState.label,
-        instantTps: trackerState.tracker.getSmoothedTPS(),
-        avgTps: trackerState.tracker.getAverageTPS(),
-        totalTokens: trackerState.tracker.getTotalTokens(),
-        elapsedMs: now - trackerState.firstTokenAt,
-      });
-    }
-
-    entries.sort((a, b) => b.instantTps - a.instantTps);
-    return entries;
-  }
-
   function removeMessageTrackerState(
     sessionId: string,
     messageId: string
@@ -607,8 +560,9 @@ export default function TpsMeterPlugin(
     ui.clear();
   }
 
-  function getPartTextCache(sessionId: string): Map<string, string> {
-    const sessionCache = partTextCache.get(sessionId) || new Map<string, string>();
+  function getPartTextCache(sessionId: string): Map<string, string | IncrementalCounter> {
+    const sessionCache =
+      partTextCache.get(sessionId) || new Map<string, string | IncrementalCounter>();
     partTextCache.set(sessionId, sessionCache);
     return sessionCache;
   }
@@ -619,17 +573,20 @@ export default function TpsMeterPlugin(
 
   function rememberDeltaText(sessionId: string, messageId: string, partId: string, delta: string): number {
     const sessionCache = getPartTextCache(sessionId);
-    const liveKey = `${messageId}:${partId}:live`;
-    const previousLiveText = sessionCache.get(liveKey) || "";
-    const nextLiveText = `${previousLiveText}${delta}`;
-    sessionCache.set(liveKey, nextLiveText);
 
     for (const partType of COUNTABLE_PART_TYPES) {
       const key = `${messageId}:${partId}:${partType}`;
-      sessionCache.set(key, `${sessionCache.get(key) || ""}${delta}`);
+      const existing = sessionCache.get(key);
+      sessionCache.set(key, `${typeof existing === "string" ? existing : ""}${delta}`);
     }
 
-    return countTokenDifference(previousLiveText, nextLiveText);
+    const liveKey = `${messageId}:${partId}:live`;
+    let counter = sessionCache.get(liveKey);
+    if (typeof counter === "string" || counter === undefined) {
+      counter = createIncrementalCounter(tokenizerAlgorithm);
+      sessionCache.set(liveKey, counter);
+    }
+    return counter.add(delta);
   }
 
 /**
@@ -691,7 +648,8 @@ function handleMessagePartUpdated(event: MessageEvent): void {
   if (part && !event.properties.delta && partText !== undefined) {
     const sessionCache = getPartTextCache(sessionId);
     const cacheKey = `${part.messageID}:${part.id}:${part.type}`;
-    const previousText = sessionCache.get(cacheKey) || "";
+    const cached = sessionCache.get(cacheKey);
+    const previousText = typeof cached === "string" ? cached : "";
     tokenCount = partText.startsWith(previousText)
       ? countTokenDifference(previousText, partText)
       : tokenizer.count(partText);
@@ -995,6 +953,33 @@ function handleMessagePartUpdated(event: MessageEvent): void {
     },
   };
 }
+
+/**
+ * Dual-host server entry.
+ *
+ * Exported as an OBJECT, not a bare function. v2 validates the default export against a
+ * schema that requires an object and rejects a callable with
+ * `SchemaError(Expected object at ["default"])`, so the older v1 bare-function style cannot
+ * load there. v1's own `PluginModule` is `{ id?, server }`, so one object satisfies both:
+ * v1 reads `server`, v2 reads `setup`, and each ignores the other's key.
+ *
+ * `setup` dispatches on the context it receives: v2's TUI process loads a package's ROOT
+ * export, so this same module is asked to be the TUI plugin there and the server plugin in
+ * the service. See src/v2/dispatch.ts.
+ */
+type DualHostServerModule = {
+  id: string;
+  server: typeof TpsMeterPlugin;
+  setup: (ctx: V2ServerContext | V2TuiContext) => Promise<V2Cleanup | void>;
+};
+
+const plugin: DualHostServerModule = {
+  id: "opencode-tps-meter",
+  server: TpsMeterPlugin,
+  setup: setupV2,
+};
+
+export default plugin;
 
 // Export types only - no helper functions to avoid OpenCode trying to load them as plugins
 export type {

--- a/src/tokenCounter.ts
+++ b/src/tokenCounter.ts
@@ -150,10 +150,99 @@ export function countTokens(text: string): number {
  * @param {string} text - The text to encode
  * @returns {number[]} - Array of token IDs (always empty in this implementation)
  */
-export function encodeText(text: string): number[] {
-  // This is a placeholder - heuristic tokenizers don't provide actual token IDs
+export function encodeText(_text: string): number[] {
+  // Placeholder: heuristic tokenizers do not produce token IDs. The parameter is kept so
+  // the published signature stays stable for anyone who imported it.
   return [];
 }
 
 // Re-export types
 export type { TokenCounter } from "./types.js";
+
+// =============================================================================
+// Incremental counting
+// =============================================================================
+
+/**
+ * A counter that consumes a stream of deltas without ever re-reading what came before.
+ *
+ * The naive approach — accumulate the text and diff `count(before)` against `count(after)`
+ * — is O(total) per delta and therefore O(n^2) per response. With the word heuristic that
+ * measured 10.2s to absorb a 186k-character response; this absorbs the same stream in
+ * roughly the time it takes to scan each chunk once.
+ *
+ * Counts are identical to the batch counters: chars/N uses ceil(totalChars / N), and the
+ * word counter counts maximal non-whitespace runs, joining runs that straddle a chunk
+ * boundary so "fo" + "x" stays one word.
+ */
+export interface IncrementalCounter {
+  /** Returns how many whole tokens this delta added. */
+  add(delta: string): number;
+  /** Total tokens counted so far. */
+  total(): number;
+  reset(): void;
+}
+
+function createCharCounter(divisor: number): IncrementalCounter {
+  let chars = 0;
+  let tokens = 0;
+  return {
+    add(delta) {
+      if (!delta) return 0;
+      chars += delta.length;
+      const next = Math.ceil(chars / divisor);
+      const added = next - tokens;
+      tokens = next;
+      return added > 0 ? added : 0;
+    },
+    total: () => tokens,
+    reset() {
+      chars = 0;
+      tokens = 0;
+    },
+  };
+}
+
+const WHITESPACE = /\s/;
+
+function createWordCounter(divisor: number): IncrementalCounter {
+  let words = 0;
+  let tokens = 0;
+  // Whether the stream so far ends mid-word, so the next chunk may continue it.
+  let openWord = false;
+
+  return {
+    add(delta) {
+      if (!delta) return 0;
+      for (let i = 0; i < delta.length; i++) {
+        const isSpace = WHITESPACE.test(delta[i] as string);
+        if (isSpace) {
+          openWord = false;
+        } else if (!openWord) {
+          // Start of a new maximal non-whitespace run.
+          words += 1;
+          openWord = true;
+        }
+      }
+      const next = Math.ceil(words / divisor);
+      const added = next - tokens;
+      tokens = next;
+      return added > 0 ? added : 0;
+    },
+    total: () => tokens,
+    reset() {
+      words = 0;
+      tokens = 0;
+      openWord = false;
+    },
+  };
+}
+
+/** Creates an incremental counter matching the given batch algorithm. */
+export function createIncrementalCounter(
+  algorithm: TokenizerAlgorithm = "heuristic"
+): IncrementalCounter {
+  if (algorithm === "word") return createWordCounter(WORDS_DIV_0_75);
+  if (algorithm === "code") return createCharCounter(CHARS_DIV_3);
+  return createCharCounter(CHARS_DIV_4);
+}

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -28,6 +28,11 @@ export function createTracker(options: TPSTrackerOptions = {}): TPSTracker {
       ? options.rollingWindowMs
       : DEFAULT_ROLLING_WINDOW_MS;
 
+  const normalHalfLifeMs =
+    typeof options.ewmaHalfLifeMs === "number" && options.ewmaHalfLifeMs > 0
+      ? options.ewmaHalfLifeMs
+      : DEFAULT_EWMA_HALF_LIFE_MS;
+
   // EWMA smoothing state
   let smoothedTps = 0;
   let lastSmoothedAt = 0;
@@ -141,7 +146,7 @@ export function createTracker(options: TPSTrackerOptions = {}): TPSTracker {
           halfLife = BURST_EWMA_HALF_LIFE_MS;
         } else {
           // Normal streaming - responsive
-          halfLife = DEFAULT_EWMA_HALF_LIFE_MS;
+          halfLife = normalHalfLifeMs;
         }
         
         const alpha = Math.exp(-Math.LN2 * timeDelta / halfLife);

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -1,10 +1,13 @@
 import type { TuiPlugin, TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui";
 import { createMemo, createSignal, Show } from "solid-js";
 import { createTracker } from "./tracker.js";
-import { createTokenizer } from "./tokenCounter.js";
+import { createTokenizer, createIncrementalCounter, type IncrementalCounter } from "./tokenCounter.js";
 import { defaultConfig, loadConfigSync } from "./config.js";
 import { COUNTABLE_PART_TYPES, INVALID_FINISH_REASONS, TOOL_CALL_FINISH_REASON } from "./constants.js";
+import { formatMeterText } from "./format.js";
 import type { Config } from "./types.js";
+import { setupTui as setupTuiV2 } from "./v2/tui.js";
+import type { V2Cleanup, V2TuiContext } from "./v2/types.js";
 
 type TrackerInstance = ReturnType<typeof createTracker>;
 type Role = "assistant" | "user";
@@ -30,37 +33,6 @@ function loadTuiConfig(): Config {
   } catch {
     return defaultConfig;
   }
-}
-
-function formatNumber(value: number): string {
-  return value.toLocaleString("en-US");
-}
-
-function formatElapsedTime(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-}
-
-function formatSnapshot(snapshot: TuiSnapshot, config: Config): string {
-  const parts: string[] = [];
-  const displayTps = snapshot.active ? snapshot.instantTps : snapshot.avgTps;
-
-  if (config.showInstant) {
-    parts.push(`${displayTps.toFixed(1)} TPS`);
-  }
-  if (config.showAverage) {
-    parts.push(`avg ${snapshot.avgTps.toFixed(1)}`);
-  }
-  if (config.showTotalTokens) {
-    parts.push(`${formatNumber(snapshot.totalTokens)} tok`);
-  }
-  if (config.showElapsed) {
-    parts.push(formatElapsedTime(snapshot.elapsedMs));
-  }
-
-  return parts.length > 0 ? parts.join(" · ") : "TPS meter";
 }
 
 function colorForSnapshot(theme: TuiPluginApi["theme"]["current"], config: Config, snapshot: TuiSnapshot) {
@@ -92,7 +64,7 @@ function MeterView(props: {
       {(snapshot) => (
         <box flexDirection="row" flexShrink={0}>
           <text fg={colorForSnapshot(props.api.theme.current, props.config, snapshot())}>
-            {formatSnapshot(snapshot(), props.config)}
+            {formatMeterText(snapshot(), props.config)}
           </text>
         </box>
       )}
@@ -106,22 +78,26 @@ const tui: TuiPlugin = async (api) => {
     return;
   }
 
-  const tokenizer = createTokenizer(
+  const tokenizerAlgorithm =
     config.fallbackTokenHeuristic === "words_div_0_75"
       ? "word"
       : config.fallbackTokenHeuristic === "chars_div_3"
         ? "code"
-        : "heuristic"
-  );
+        : "heuristic";
+  const tokenizer = createTokenizer(tokenizerAlgorithm);
   const [snapshots, setSnapshots] = createSignal(new Map<string, TuiSnapshot>());
   const sessions = new Map<string, SessionState>();
-  const partTextCache = new Map<string, Map<string, string>>();
+  // Part-type keys hold accumulated TEXT (the full-part path diffs against it); the `:live`
+  // key holds an incremental counter, since it was only ever read to compute a token
+  // difference and re-counting the whole string per delta is O(total).
+  const partTextCache = new Map<string, Map<string, string | IncrementalCounter>>();
   const messageRoles = new Map<string, Map<string, Role>>();
   const publishTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const disposers: Array<() => void> = [];
 
-  function getPartTextCache(sessionId: string): Map<string, string> {
-    const cache = partTextCache.get(sessionId) ?? new Map<string, string>();
+  function getPartTextCache(sessionId: string): Map<string, string | IncrementalCounter> {
+    const cache =
+      partTextCache.get(sessionId) ?? new Map<string, string | IncrementalCounter>();
     partTextCache.set(sessionId, cache);
     return cache;
   }
@@ -283,17 +259,20 @@ const tui: TuiPlugin = async (api) => {
 
   function rememberDeltaText(sessionId: string, messageId: string, partId: string, delta: string): number {
     const cache = getPartTextCache(sessionId);
-    const liveKey = `${messageId}:${partId}:live`;
-    const previousLiveText = cache.get(liveKey) ?? "";
-    const nextLiveText = `${previousLiveText}${delta}`;
-    cache.set(liveKey, nextLiveText);
 
     for (const partType of COUNTABLE_PART_TYPES) {
       const key = `${messageId}:${partId}:${partType}`;
-      cache.set(key, `${cache.get(key) ?? ""}${delta}`);
+      const existing = cache.get(key);
+      cache.set(key, `${typeof existing === "string" ? existing : ""}${delta}`);
     }
 
-    return countTokenDifference(previousLiveText, nextLiveText);
+    const liveKey = `${messageId}:${partId}:live`;
+    let counter = cache.get(liveKey);
+    if (typeof counter === "string" || counter === undefined) {
+      counter = createIncrementalCounter(tokenizerAlgorithm);
+      cache.set(liveKey, counter);
+    }
+    return counter.add(delta);
   }
 
   function shouldTrackText(sessionId: string, messageId: string, text: string): boolean {
@@ -398,7 +377,8 @@ const tui: TuiPlugin = async (api) => {
     const sessionCache = getPartTextCache(event.properties.sessionID);
 
     const cacheKey = `${part.messageID}:${part.id}:${part.type}`;
-    const previousText = sessionCache.get(cacheKey) ?? "";
+    const cached = sessionCache.get(cacheKey);
+    const previousText = typeof cached === "string" ? cached : "";
     if (shouldTrackText(event.properties.sessionID, part.messageID, text)) {
       const tokenCount = text.startsWith(previousText)
         ? countTokenDifference(previousText, text)
@@ -428,9 +408,21 @@ const tui: TuiPlugin = async (api) => {
   });
 };
 
-const plugin: TuiPluginModule = {
+/**
+ * Dual-host TUI entry.
+ *
+ * v1 reads `tui`; v2 reads `setup`. Both hosts ignore the key they do not know, so one
+ * module serves `opencode` and `opencode2`. v2 users can also point at the dedicated
+ * `opencode-tps-meter/v2/tui` entry, which carries no v1 baggage.
+ */
+type DualHostTuiModule = TuiPluginModule & {
+  setup: (ctx: V2TuiContext) => V2Cleanup | void;
+};
+
+const plugin: DualHostTuiModule = {
   id: "opencode-tps-meter",
   tui,
+  setup: setupTuiV2,
 };
 
 export default plugin;

--- a/src/types.ts
+++ b/src/types.ts
@@ -341,6 +341,14 @@ export interface TPSTrackerOptions {
   sessionId?: string;
   /** Optional rolling window duration in milliseconds */
   rollingWindowMs?: number;
+  /**
+   * EWMA half-life for normal streaming, in milliseconds.
+   *
+   * Lower responds faster at the cost of a jumpier reading. Defaults to
+   * DEFAULT_EWMA_HALF_LIFE_MS so v1 behaviour is unchanged; v2 opts into a faster value
+   * because its rolling window already does the smoothing.
+   */
+  ewmaHalfLifeMs?: number;
 }
 
 /**

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -41,7 +41,6 @@ export function createUIManager(
   let lastToastAt = 0;
   let lastToastMessage = "";
   let pendingState: DisplayState | null = null;
-  let lastDisplayedState: DisplayState | null = null;
 
   /**
    * Formats milliseconds to MM:SS display
@@ -268,7 +267,6 @@ export function createUIManager(
         tpsForColor = Math.max(...pendingState.agents.map(a => a.instantTps));
       }
       display(formatted, false, tpsForColor);
-      lastDisplayedState = { ...pendingState };
       pendingState = null;
     }
   }
@@ -357,7 +355,6 @@ export function createUIManager(
 
       // Reset state
       pendingState = null;
-      lastDisplayedState = null;
 
     },
 

--- a/src/v2/dispatch.ts
+++ b/src/v2/dispatch.ts
@@ -1,0 +1,62 @@
+/**
+ * Context-dispatching v2 setup.
+ *
+ * v2 gives server and TUI plugins the identical `{ id, setup }` signature, and the TUI
+ * process loads a plugin package's ROOT export (verified against `opencode2` beta 17639,
+ * and matching how other v2 TUI plugins lay out their package.json). So the root module
+ * must serve whichever process loads it, and can only tell them apart by the context it
+ * is handed:
+ *
+ *   TUI context    -> has `ui.slot` + `data.on`
+ *   server context -> has `event.subscribe`
+ *
+ * The TUI module is loaded with a DYNAMIC import on purpose. Importing `@opentui/solid`
+ * inside the service process throws
+ * `Error: Environment variable "OPENTUI_FORCE_WCWIDTH" is already registered`, which kills
+ * the plugin load. Keeping it behind a runtime import means the service never touches it.
+ *
+ * @module v2/dispatch
+ */
+
+import { setupServer } from "./server.js";
+import type { V2Cleanup, V2ServerContext, V2TuiContext } from "./types.js";
+
+/** Built sibling of the root bundle. Non-literal so bundlers leave it as a runtime import. */
+const TUI_MODULE_SPECIFIER = "./tui.mjs";
+
+interface TuiModule {
+  default?: { setup?: (ctx: V2TuiContext) => V2Cleanup | void };
+  setupTui?: (ctx: V2TuiContext) => V2Cleanup | void;
+}
+
+function isTuiContext(ctx: unknown): ctx is V2TuiContext {
+  const candidate = ctx as V2TuiContext | undefined;
+  return (
+    typeof candidate?.ui?.slot === "function" && typeof candidate?.data?.on === "function"
+  );
+}
+
+function isServerContext(ctx: unknown): ctx is V2ServerContext {
+  return typeof (ctx as V2ServerContext | undefined)?.event?.subscribe === "function";
+}
+
+/**
+ * Routes a v2 `setup` call to the TUI or server implementation based on the context shape.
+ * Returns nothing for an unrecognised context rather than throwing, so an API change in the
+ * beta degrades to "no meter" instead of a failed plugin load.
+ */
+export async function setupAuto(
+  ctx: V2TuiContext | V2ServerContext
+): Promise<V2Cleanup | void> {
+  if (isTuiContext(ctx)) {
+    const mod = (await import(TUI_MODULE_SPECIFIER)) as TuiModule;
+    const setup = mod.setupTui ?? mod.default?.setup;
+    return setup ? setup(ctx) : undefined;
+  }
+
+  if (isServerContext(ctx)) {
+    return setupServer(ctx);
+  }
+
+  return undefined;
+}

--- a/src/v2/ledger.ts
+++ b/src/v2/ledger.ts
@@ -1,0 +1,163 @@
+/**
+ * Durable throughput ledger, keyed by model.
+ *
+ * v1 could not do this at all: its TUI KV is documented as
+ * `@deprecated Persistent TUI KV storage is not supported in V2`, so a v1 TUI plugin loses
+ * every reading when the TUI exits. v2's `ctx.storage.store` persists to disk under a
+ * cross-process lock and live-syncs to every running TUI window, so a rollup written by one
+ * window is immediately visible in another.
+ *
+ * Degrades to an in-memory rollup when the host exposes no storage, so the dashboard still
+ * works on a host that predates the API.
+ *
+ * @module v2/ledger
+ */
+
+import type { V2StoreHandle, V2Storage } from "./types.js";
+
+export interface LedgerEntry {
+  /** Settled steps folded into this entry. */
+  samples: number;
+  /** Provider-reported tokens, summed. */
+  tokens: number;
+  /** Generation milliseconds (tool execution already subtracted), summed. */
+  generationMs: number;
+  /** Provider-reported cost, summed. */
+  cost: number;
+  /** Best single-step tokens/sec seen. */
+  bestTps: number;
+  /** Most recent step's tokens/sec. */
+  lastTps: number;
+  /** Mean time-to-first-token across samples with a measurement. */
+  meanTtftMs: number;
+  ttftSamples: number;
+}
+
+export interface LedgerData {
+  version: number;
+  models: Record<string, LedgerEntry>;
+}
+
+export interface StepMeasurement {
+  modelKey: string;
+  tokens: number;
+  generationMs: number;
+  cost: number;
+  ttftMs: number;
+}
+
+export interface V2Ledger {
+  /** Folds one settled step into the rollup. Interrupted turns must not be passed here. */
+  record(measurement: StepMeasurement): void;
+  read(): LedgerData;
+  /** Mean tokens/sec for a model, or 0 when unmeasured. */
+  meanTps(modelKey: string): number;
+  clear(): void;
+}
+
+const EMPTY: LedgerData = { version: 1, models: {} };
+
+function emptyEntry(): LedgerEntry {
+  return {
+    samples: 0,
+    tokens: 0,
+    generationMs: 0,
+    cost: 0,
+    bestTps: 0,
+    lastTps: 0,
+    meanTtftMs: 0,
+    ttftSamples: 0,
+  };
+}
+
+export function createLedger(storage?: V2Storage): V2Ledger {
+  let fallback: LedgerData = { version: 1, models: {} };
+
+  // The host's storage API is beta and hand-typed here. If calling it throws — wrong
+  // signature, or a Solid store that must be created inside a reactive owner — fall back to
+  // the in-memory rollup rather than taking the whole plugin down with us.
+  let handle: V2StoreHandle<LedgerData> | undefined;
+  try {
+    handle = storage?.store<LedgerData>("ledger", { initial: { ...EMPTY, models: {} } });
+    if (handle && (!Array.isArray(handle) || typeof handle[1] !== "function")) {
+      handle = undefined;
+    }
+  } catch {
+    handle = undefined;
+  }
+
+  function read(): LedgerData {
+    if (!handle) {
+      return fallback;
+    }
+    try {
+      return handle[0] ?? fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
+  function mutate(fn: (draft: LedgerData) => void): void {
+    if (handle) {
+      try {
+        void handle[1](fn);
+        return;
+      } catch {
+        // Drop through to the in-memory path for the rest of this session.
+        handle = undefined;
+      }
+    }
+    // Structured clone keeps the in-memory path copy-on-write like the store path.
+    const draft: LedgerData = JSON.parse(JSON.stringify(fallback)) as LedgerData;
+    fn(draft);
+    fallback = draft;
+  }
+
+  return {
+    record(measurement) {
+      const { modelKey, tokens, generationMs, cost, ttftMs } = measurement;
+      if (!modelKey || tokens <= 0 || generationMs <= 0) {
+        return;
+      }
+      const tps = tokens / (generationMs / 1000);
+      if (!Number.isFinite(tps) || tps <= 0) {
+        return;
+      }
+
+      mutate((draft) => {
+        if (!draft.models) {
+          draft.models = {};
+        }
+        const entry = draft.models[modelKey] ?? emptyEntry();
+        entry.samples += 1;
+        entry.tokens += tokens;
+        entry.generationMs += generationMs;
+        entry.cost += cost > 0 ? cost : 0;
+        entry.lastTps = tps;
+        entry.bestTps = Math.max(entry.bestTps, tps);
+        if (ttftMs > 0) {
+          entry.meanTtftMs =
+            (entry.meanTtftMs * entry.ttftSamples + ttftMs) / (entry.ttftSamples + 1);
+          entry.ttftSamples += 1;
+        }
+        draft.models[modelKey] = entry;
+      });
+    },
+
+    read,
+
+    meanTps(modelKey) {
+      const entry = read().models?.[modelKey];
+      if (!entry || entry.generationMs <= 0) {
+        return 0;
+      }
+      return entry.tokens / (entry.generationMs / 1000);
+    },
+
+    clear() {
+      mutate((draft) => {
+        draft.models = {};
+      });
+    },
+  };
+}

--- a/src/v2/meter.ts
+++ b/src/v2/meter.ts
@@ -1,0 +1,801 @@
+/**
+ * Session tracking core for OpenCode v2.
+ *
+ * Framework-free so both the v2 TUI entry and the v2 server entry can drive it.
+ * Mirrors the v1 TUI state machine (see src/tui.tsx) so displayed numbers stay
+ * consistent across hosts, but consumes the v2 event vocabulary:
+ *
+ *   v1 message.part.delta (field "text")  -> v2 session.text.delta
+ *   v1 message.part.updated               -> v2 session.text.delta / session.reasoning.delta
+ *   v1 message.updated (time.completed)   -> v2 session.step.ended
+ *   v1 session.idle                       -> v2 session.idle  (unchanged)
+ *
+ * Unlike v1 there is no role filtering: text/reasoning deltas are assistant output by
+ * construction, so the message-role and part-type caches are gone.
+ *
+ * @module v2/meter
+ */
+
+import { createTracker } from "../tracker.js";
+import { createIncrementalCounter, type IncrementalCounter } from "../tokenCounter.js";
+import { createMetrics } from "./metrics.js";
+import {
+  CLEANUP_INTERVAL_MS,
+  INVALID_FINISH_REASONS,
+  MAX_MESSAGE_AGE_MS,
+  MAX_RETAINED_SNAPSHOTS,
+  DEFAULT_UPDATE_INTERVAL_MS,
+  TOOL_CALL_FINISH_REASON,
+  V2_EWMA_HALF_LIFE_MS,
+  V2_UPDATE_INTERVAL_MS,
+} from "../constants.js";
+import type { Config, TPSTracker } from "../types.js";
+import type {
+  V2AnyMeterEvent,
+  V2SessionExecutionSettled,
+  V2SessionExecutionStarted,
+  V2SessionStepStarted,
+  V2SessionToolCalled,
+  V2SessionToolSettled,
+  V2SessionReasoningDelta,
+  V2SessionStepEnded,
+  V2SessionTextDelta,
+  V2SessionUsageUpdated,
+  V2UnknownEvent,
+} from "./types.js";
+
+/** Event types the meter reacts to. Anything else is ignored. */
+const HANDLED_EVENT_TYPES: ReadonlySet<string> = new Set<V2AnyMeterEvent["type"]>([
+  "session.text.delta",
+  "session.reasoning.delta",
+  "session.step.ended",
+  "session.usage.updated",
+  "session.idle",
+  "session.step.started",
+  "session.tool.called",
+  "session.tool.success",
+  "session.tool.failed",
+  "session.execution.started",
+  "session.execution.succeeded",
+  "session.execution.failed",
+  "session.execution.interrupted",
+]);
+
+/** A rendered view of one session's throughput. */
+export interface V2Snapshot {
+  sessionID: string;
+  instantTps: number;
+  avgTps: number;
+  totalTokens: number;
+  elapsedMs: number;
+  /** True while tokens are actively streaming; false once the turn settles. */
+  active: boolean;
+  /**
+   * Tokens the session spent that no step reported: auto-title generation and context
+   * compaction. Derived as (cumulative session usage - sum of observed step deltas), so it
+   * is only meaningful once at least one session.usage.updated has arrived. 0 when unknown.
+   */
+  overheadTokens: number;
+  /** Milliseconds from turn start to first streamed token. 0 when unknown. */
+  ttftMs: number;
+  /** Milliseconds this turn spent inside tool execution. */
+  toolMs: number;
+  /** Tokens per second excluding tool execution time — the model's true rate. */
+  generationTps: number;
+  /** `providerID/modelID[#variant]`, or "default" before attribution arrives. */
+  modelKey: string;
+  /** Agent that produced the current step, when known. */
+  agent?: string;
+  /** Calibration samples backing this model's live estimate. 0 = uncalibrated. */
+  calibrationSamples: number;
+  /** True when the turn was aborted; the reading is not trustworthy. */
+  interrupted: boolean;
+}
+
+/** One settled step, emitted for durable rollups. Interrupted turns are never emitted. */
+export interface V2StepMeasurement {
+  sessionID: string;
+  modelKey: string;
+  agent?: string;
+  tokens: number;
+  /** Elapsed with tool execution subtracted. */
+  generationMs: number;
+  cost: number;
+  ttftMs: number;
+}
+
+export interface V2MeterHooks {
+  readonly onStepSettled?: (measurement: V2StepMeasurement) => void;
+}
+
+export interface V2Meter {
+  /** Feeds one event in. Unrecognised events are ignored. */
+  handleEvent(event: V2UnknownEvent): void;
+  /** Current snapshot per session. */
+  getSnapshots(): ReadonlyMap<string, V2Snapshot>;
+  /** Subscribes to snapshot changes. Returns an unsubscribe function. */
+  subscribe(listener: (snapshots: ReadonlyMap<string, V2Snapshot>) => void): () => void;
+  /** Clears all timers and state. */
+  dispose(): void;
+}
+
+interface SessionState {
+  tracker: TPSTracker;
+  firstTokenAt: number | null;
+  /**
+   * Wall-clock time of the last publish.
+   *
+   * Deliberately NOT the host event clock: timers fire on wall time, so throttling has to be
+   * decided on the same clock or the two disagree and updates are skipped. Token maths still
+   * uses host time (firstTokenAt / lastTokenAt).
+   */
+  lastPublishedWallAt: number;
+  /** Wall-clock time of the first token, for the startup-delay gate. */
+  firstTokenWallAt: number | null;
+  /** Tokens have been recorded since the last publish. */
+  dirty: boolean;
+  /**
+   * Host time of the most recent token.
+   *
+   * The shared tracker measures elapsed with its own Date.now(), which would mix the local
+   * clock with the host-stamped event clock we record tokens against. v2 derives elapsed
+   * from these two host timestamps instead so both ends of the window share one clock.
+   */
+  lastTokenAt: number | null;
+  lastPublishedAt: number;
+}
+
+/**
+ * Session-scoped usage accounting.
+ *
+ * Deliberately NOT part of SessionState: that is per-TURN and is destroyed on every
+ * step end and idle, whereas cumulative usage and the observed-step sum must accumulate
+ * across the whole session for the overhead residual to mean anything.
+ */
+interface SessionUsage {
+  /**
+   * Latest CUMULATIVE session usage from session.usage.updated. NOT a per-step figure:
+   * the host publishes it from the accumulated session row, so it also includes auto-title
+   * generation and compaction tokens.
+   */
+  cumulativeTokens: number;
+  /** Sum of every per-step delta observed this session. */
+  observedStepTokens: number;
+}
+
+/**
+ * Coerces a provider-reported token field to a safe non-negative number.
+ *
+ * Guards the `output + reasoning` arithmetic: these values cross a process boundary from
+ * the host, and a non-numeric field would silently turn the sum into string concatenation
+ * ("100" + "50" -> "10050") and render as a bogus total.
+ */
+function toTokenCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/**
+ * Resolves the timestamp to attribute an event's tokens to.
+ *
+ * The TUI delivers events in ~10ms batches, so `Date.now()` inside a handler is the FLUSH
+ * time and every event in a batch shares it — which flattens the rolling window and skews
+ * the instantaneous rate. Every v2 event carries a host-stamped `created` instead (v1 events
+ * carried no timestamp at all, which is why v1 had to use local time).
+ *
+ * Falls back to local time if `created` is missing or implausible, so a payload change
+ * degrades to v1-quality timing rather than producing garbage.
+ */
+function eventTime(event: { created?: unknown }, fallback: number): number {
+  const created = event.created;
+  if (typeof created !== "number" || !Number.isFinite(created) || created <= 0) {
+    return fallback;
+  }
+  // Guard against a foreign epoch or clock skew: anything more than a day out is not usable.
+  if (Math.abs(created - fallback) > 86_400_000) {
+    return fallback;
+  }
+  return created;
+}
+
+/** Narrows an arbitrary v2 event to one the meter understands. */
+function asMeterEvent(event: V2UnknownEvent): V2AnyMeterEvent | undefined {
+  if (!event || typeof event.type !== "string" || !HANDLED_EVENT_TYPES.has(event.type)) {
+    return undefined;
+  }
+  const data = event.data;
+  if (!data || typeof data !== "object") {
+    return undefined;
+  }
+  // Every handled event carries a sessionID; without one there is nothing to attribute.
+  const sessionID = (data as { sessionID?: unknown }).sessionID;
+  if (typeof sessionID !== "string" || sessionID.length === 0) {
+    return undefined;
+  }
+  return event as unknown as V2AnyMeterEvent;
+}
+
+export function createMeter(config: Config, hooks?: V2MeterHooks): V2Meter {
+  /**
+   * Display throttle for v2.
+   *
+   * The host delivers events in ~10ms batches, so publishing faster than that cannot show
+   * anything new — this is the useful floor. The v1 default (50ms) exists for the toast path,
+   * which is far more expensive to update; an explicit user setting still wins.
+   */
+  const publishIntervalMs =
+    config.updateIntervalMs === DEFAULT_UPDATE_INTERVAL_MS
+      ? V2_UPDATE_INTERVAL_MS
+      : config.updateIntervalMs;
+
+  const algorithm =
+    config.fallbackTokenHeuristic === "words_div_0_75"
+      ? "word"
+      : config.fallbackTokenHeuristic === "chars_div_3"
+        ? "code"
+        : "heuristic";
+
+  const sessions = new Map<string, SessionState>();
+  const metrics = createMetrics();
+  /**
+   * One incremental counter per `${messageID}:${ordinal}:${kind}`.
+   *
+   * Previously this held the accumulated TEXT and re-counted it on every delta, which is
+   * O(total) per delta and O(n^2) per response — the word heuristic took 10.2s to absorb a
+   * 186k-character stream. Counters absorb each chunk once and never look back, which also
+   * means the full response text is no longer retained in memory.
+   */
+  const streamText = new Map<string, Map<string, IncrementalCounter>>();
+  const publishTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const listeners = new Set<(snapshots: ReadonlyMap<string, V2Snapshot>) => void>();
+  /** Last time each session produced an event, for the stale sweep. */
+  const lastActivityAt = new Map<string, number>();
+  /** Usage accounting that survives per-turn resets. */
+  const sessionUsage = new Map<string, SessionUsage>();
+
+  function getSessionUsage(sessionID: string): SessionUsage {
+    let usage = sessionUsage.get(sessionID);
+    if (!usage) {
+      usage = { cumulativeTokens: 0, observedStepTokens: 0 };
+      sessionUsage.set(sessionID, usage);
+    }
+    return usage;
+  }
+
+  let snapshots: ReadonlyMap<string, V2Snapshot> = new Map();
+  let lastSweepAt = 0;
+
+  function setSnapshots(next: ReadonlyMap<string, V2Snapshot>): void {
+    snapshots = next;
+    for (const listener of listeners) {
+      listener(snapshots);
+    }
+  }
+
+  function mutateSnapshots(mutate: (draft: Map<string, V2Snapshot>) => void): void {
+    const draft = new Map(snapshots);
+    mutate(draft);
+    setSnapshots(draft);
+  }
+
+  function getStreamCache(sessionID: string): Map<string, IncrementalCounter> {
+    const cache = streamText.get(sessionID) ?? new Map<string, IncrementalCounter>();
+    streamText.set(sessionID, cache);
+    return cache;
+  }
+
+  function getSessionState(sessionID: string): SessionState {
+    let state = sessions.get(sessionID);
+    if (state) {
+      return state;
+    }
+    state = {
+      tracker: createTracker({
+        sessionId: sessionID,
+        rollingWindowMs: config.rollingWindowMs,
+        ewmaHalfLifeMs: V2_EWMA_HALF_LIFE_MS,
+      }),
+      firstTokenAt: null,
+      lastTokenAt: null,
+      lastPublishedAt: 0,
+      lastPublishedWallAt: 0,
+      firstTokenWallAt: null,
+      dirty: false,
+    };
+    sessions.set(sessionID, state);
+    return state;
+  }
+
+  function clearPublishTimer(sessionID: string): void {
+    const timer = publishTimers.get(sessionID);
+    if (timer) {
+      clearTimeout(timer);
+      publishTimers.delete(sessionID);
+    }
+  }
+
+  function resetSession(sessionID: string): void {
+    clearPublishTimer(sessionID);
+    sessions.delete(sessionID);
+    streamText.delete(sessionID);
+  }
+
+  /**
+   * Drops sessions that went quiet without a terminal event.
+   *
+   * A turn normally ends via session.step.ended or session.idle, both of which reset the
+   * session. A crash, cancel, or dropped connection produces neither, which would strand the
+   * per-session state for the life of the process.
+   *
+   * The last READING is deliberately kept: v1's TUI had no sweep and left the final numbers
+   * on screen indefinitely, so dropping them here made the meter appear to forget after five
+   * quiet minutes. Only the heavy state (tracker, stream counters, metrics, usage) is freed;
+   * retained readings are capped separately so churn cannot grow them without bound.
+   */
+  function sweepStaleSessions(now: number): void {
+    if (now - lastSweepAt < CLEANUP_INTERVAL_MS) {
+      return;
+    }
+    lastSweepAt = now;
+
+    const stale: string[] = [];
+    for (const [sessionID, seenAt] of lastActivityAt) {
+      if (now - seenAt > MAX_MESSAGE_AGE_MS) {
+        stale.push(sessionID);
+      }
+    }
+    if (stale.length === 0) {
+      return;
+    }
+
+    for (const sessionID of stale) {
+      resetSession(sessionID);
+      sessionUsage.delete(sessionID);
+      metrics.forget(sessionID);
+      // Keep the activity stamp only while a reading survives, so it can be aged out later.
+      if (!snapshots.has(sessionID)) {
+        lastActivityAt.delete(sessionID);
+      }
+    }
+
+    if (snapshots.size <= MAX_RETAINED_SNAPSHOTS) {
+      return;
+    }
+    const oldestFirst = [...snapshots.keys()].sort(
+      (a, b) => (lastActivityAt.get(a) ?? 0) - (lastActivityAt.get(b) ?? 0)
+    );
+    const evict = oldestFirst.slice(0, snapshots.size - MAX_RETAINED_SNAPSHOTS);
+    for (const sessionID of evict) {
+      lastActivityAt.delete(sessionID);
+    }
+    mutateSnapshots((draft) => {
+      for (const sessionID of evict) {
+        draft.delete(sessionID);
+      }
+    });
+  }
+
+  /**
+   * Fields derived from turn decomposition and attribution.
+   *
+   * generationTps subtracts tool execution from the elapsed window, so a turn that spent
+   * 8s of its 10s running a shell command reports the model's real rate rather than an
+   * average diluted by waiting. v1 had no event timestamps and so could not do this.
+   */
+  /** Elapsed measured on the host clock, falling back to the tracker before two samples. */
+  function elapsedFor(state: SessionState): number {
+    if (state.firstTokenAt !== null && state.lastTokenAt !== null) {
+      const span = state.lastTokenAt - state.firstTokenAt;
+      if (span > 0) {
+        return span;
+      }
+    }
+    return state.tracker.getElapsedMs();
+  }
+
+  function derivedFields(sessionID: string, totalTokens: number, elapsedMs: number) {
+    const turn = metrics.turnOf(sessionID);
+    const attribution = metrics.attributionOf(sessionID);
+    const generationMs = Math.max(0, elapsedMs - turn.toolMs);
+    return {
+      ttftMs: turn.ttftMs,
+      toolMs: turn.toolMs,
+      generationTps: generationMs > 0 ? totalTokens / (generationMs / 1000) : 0,
+      modelKey: attribution.key,
+      agent: attribution.agent,
+      calibrationSamples: metrics.samplesOf(sessionID),
+      interrupted: turn.interrupted,
+    };
+  }
+
+  function publish(sessionID: string, active: boolean, now: number): void {
+    const state = sessions.get(sessionID);
+    if (!state) {
+      return;
+    }
+
+    const totalTokens = state.tracker.getTotalTokens();
+    if (totalTokens === 0) {
+      return;
+    }
+
+    clearPublishTimer(sessionID);
+    state.lastPublishedAt = now;
+    state.lastPublishedWallAt = Date.now();
+    state.dirty = false;
+    mutateSnapshots((draft) => {
+      const elapsedMs = elapsedFor(state);
+      draft.set(sessionID, {
+        sessionID,
+        instantTps: state.tracker.getSmoothedTPS(),
+        avgTps: elapsedMs > 0 ? totalTokens / (elapsedMs / 1000) : state.tracker.getAverageTPS(),
+        totalTokens,
+        elapsedMs,
+        active,
+        overheadTokens: overheadFor(sessionID),
+        ...derivedFields(sessionID, totalTokens, elapsedMs),
+      });
+    });
+  }
+
+  /**
+   * Publishes terminal stats for a completed turn.
+   * `totalTokens` is provider-reported where available, so the final figure is exact
+   * rather than heuristic.
+   */
+  /**
+   * Tokens billed to the session that no step accounted for.
+   *
+   * session.usage.updated is cumulative and includes work the user never asked for
+   * (auto-title, compaction); session.step.ended deltas cover only real turns. The residual
+   * between them IS that hidden overhead.
+   */
+  function overheadFor(sessionID: string): number {
+    const usage = sessionUsage.get(sessionID);
+    if (!usage || usage.cumulativeTokens <= 0) {
+      return 0;
+    }
+    return Math.max(0, usage.cumulativeTokens - usage.observedStepTokens);
+  }
+
+  function publishFinal(
+    sessionID: string,
+    totalTokens: number,
+    avgTps: number,
+    elapsedMs: number,
+    overheadTokens: number
+  ): void {
+    if (totalTokens === 0 || elapsedMs < config.initialDisplayDelayMs) {
+      return;
+    }
+    mutateSnapshots((draft) => {
+      draft.set(sessionID, {
+        sessionID,
+        instantTps: 0,
+        avgTps,
+        totalTokens,
+        elapsedMs,
+        active: false,
+        overheadTokens,
+        ...derivedFields(sessionID, totalTokens, elapsedMs),
+      });
+    });
+  }
+
+  function clearActiveSnapshot(sessionID: string): void {
+    const current = snapshots.get(sessionID);
+    if (current?.active) {
+      mutateSnapshots((draft) => {
+        draft.delete(sessionID);
+      });
+    }
+  }
+
+  /**
+   * Freezes the meter at its last value instead of clearing it, so the reading stays
+   * on screen between tool calls and after the turn ends.
+   */
+  function persistIdleSnapshot(sessionID: string, now: number): void {
+    const state = sessions.get(sessionID);
+    if (state && state.tracker.getTotalTokens() > 0) {
+      if (state.firstTokenAt !== null && now - state.firstTokenAt >= config.initialDisplayDelayMs) {
+        publish(sessionID, false, now);
+        return;
+      }
+    }
+
+    const current = snapshots.get(sessionID);
+    if (current?.active) {
+      mutateSnapshots((draft) => {
+        draft.set(sessionID, { ...current, active: false });
+      });
+    }
+  }
+
+  /**
+   * How long the startup delay has been open for.
+   *
+   * Measured as the larger of host-event elapsed and wall elapsed. In production the two
+   * agree; they diverge only in degenerate cases — a single delta advances host time by
+   * nothing, while a synchronous burst of host-timestamped events advances wall time by
+   * nothing. Taking the max means neither case can stall the first reading.
+   */
+  function startupElapsed(state: SessionState, wallNow: number, hostNow: number): number {
+    const host = state.firstTokenAt === null ? 0 : hostNow - state.firstTokenAt;
+    const wall = state.firstTokenWallAt === null ? 0 : wallNow - state.firstTokenWallAt;
+    return Math.max(host, wall);
+  }
+
+  /**
+   * Ensures a publish happens once the throttle window closes.
+   *
+   * The timer publishes whatever is pending rather than re-testing the conditions that
+   * scheduled it. Re-testing meant a timer could fire, fail a guard, and silently drop the
+   * update — leaving the meter stale until the next delta happened to arrive.
+   */
+  function scheduleActivePublish(sessionID: string, delayMs: number): void {
+    if (publishTimers.has(sessionID)) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      publishTimers.delete(sessionID);
+      const state = sessions.get(sessionID);
+      if (
+        state === undefined ||
+        !state.dirty ||
+        state.firstTokenAt === null ||
+        state.lastTokenAt === null ||
+        state.tracker.getTotalTokens() <= 0
+      ) {
+        return;
+      }
+      if (startupElapsed(state, Date.now(), state.lastTokenAt) < config.initialDisplayDelayMs) {
+        return;
+      }
+      publish(sessionID, true, state.lastTokenAt);
+    }, delayMs);
+    publishTimers.set(sessionID, timer);
+  }
+
+  function maybePublishActive(sessionID: string, now: number): void {
+    const state = sessions.get(sessionID);
+    if (!state || state.firstTokenAt === null) {
+      return;
+    }
+    state.dirty = true;
+
+    if (state.tracker.getSmoothedTPS() < config.minVisibleTPS) {
+      return;
+    }
+
+    // The throttle is decided on the wall clock, because that is the clock the timer fires
+    // on — deciding it on host time made the two disagree and updates were skipped.
+    const wallNow = Date.now();
+    const initialDelayRemaining =
+      config.initialDisplayDelayMs - startupElapsed(state, wallNow, now);
+    const throttleDelayRemaining = publishIntervalMs - (wallNow - state.lastPublishedWallAt);
+
+    if (initialDelayRemaining <= 0 && throttleDelayRemaining <= 0) {
+      publish(sessionID, true, now);
+      return;
+    }
+
+    scheduleActivePublish(sessionID, Math.max(1, initialDelayRemaining, throttleDelayRemaining));
+  }
+
+  /**
+   * Counts the tokens a delta adds.
+   *
+   * Delegates to a per-stream incremental counter. Counting each chunk in isolation would
+   * drift, because heuristics like chars/4 are not additive across chunk boundaries; the
+   * counter keeps the running total instead, so the result matches counting the whole text
+   * at once without ever re-reading it.
+   */
+  function countDelta(
+    sessionID: string,
+    messageID: string,
+    ordinal: number,
+    kind: "text" | "reasoning",
+    delta: string
+  ): number {
+    const cache = getStreamCache(sessionID);
+    const key = `${messageID}:${ordinal}:${kind}`;
+    let counter = cache.get(key);
+    if (!counter) {
+      counter = createIncrementalCounter(algorithm);
+      cache.set(key, counter);
+    }
+    return counter.add(delta);
+  }
+
+  function recordTokens(sessionID: string, tokenCount: number, at: number): void {
+    if (tokenCount <= 0) {
+      return;
+    }
+    const now = at;
+    const state = getSessionState(sessionID);
+    if (state.firstTokenAt === null) {
+      state.firstTokenAt = now;
+      state.firstTokenWallAt = Date.now();
+    }
+    state.lastTokenAt = now;
+    state.tracker.recordTokens(tokenCount, now);
+    maybePublishActive(sessionID, now);
+  }
+
+  function handleDelta(event: V2SessionTextDelta | V2SessionReasoningDelta): void {
+    const { sessionID, assistantMessageID, ordinal, delta } = event.data;
+    if (typeof delta !== "string" || delta.length === 0) {
+      return;
+    }
+    const kind = event.type === "session.reasoning.delta" ? "reasoning" : "text";
+    const at = eventTime(event, Date.now());
+    const raw = countDelta(sessionID, assistantMessageID, ordinal, kind, delta);
+    metrics.onFirstToken(sessionID, at);
+    // scale() applies the model's learned chars-per-token factor and carries the fractional
+    // remainder, so calibration never silently drops sub-token amounts.
+    recordTokens(sessionID, metrics.scale(sessionID, raw), at);
+  }
+
+  function handleUsageUpdated(event: V2SessionUsageUpdated): void {
+    const { sessionID, tokens } = event.data;
+    if (!tokens) {
+      return;
+    }
+    getSessionUsage(sessionID).cumulativeTokens =
+      toTokenCount(tokens.output) + toTokenCount(tokens.reasoning);
+  }
+
+  function handleStepStarted(event: V2SessionStepStarted): void {
+    metrics.onStepStarted(event.data.sessionID, event.data.model, event.data.agent);
+  }
+
+  function handleToolCalled(event: V2SessionToolCalled): void {
+    metrics.onToolCalled(event.data.sessionID, event.data.id, eventTime(event, Date.now()));
+  }
+
+  function handleToolSettled(event: V2SessionToolSettled): void {
+    metrics.onToolSettled(event.data.sessionID, event.data.id, eventTime(event, Date.now()));
+  }
+
+  function handleExecutionStarted(event: V2SessionExecutionStarted): void {
+    metrics.onExecutionStarted(event.data.sessionID, eventTime(event, Date.now()));
+  }
+
+  function handleExecutionSettled(event: V2SessionExecutionSettled): void {
+    metrics.onExecutionSettled(
+      event.data.sessionID,
+      event.type === "session.execution.interrupted"
+    );
+  }
+
+  function handleStepEnded(event: V2SessionStepEnded): void {
+    const { sessionID, finish, tokens } = event.data;
+    const now = eventTime(event, Date.now());
+
+    // Every settled step consumed tokens, including one that ends to run tools — record it
+    // before any early return or the overhead residual overcounts.
+    const settledTokens = toTokenCount(tokens?.output) + toTokenCount(tokens?.reasoning);
+    if (settledTokens > 0) {
+      getSessionUsage(sessionID).observedStepTokens += settledTokens;
+    }
+    // One closed calibration loop per step: heuristic tokens streamed vs provider truth.
+    metrics.calibrate(sessionID, settledTokens);
+
+    // A step that ends to run tools is not the end of the turn — hold the last reading
+    // on screen so the meter does not blink out between tool calls.
+    if (finish === TOOL_CALL_FINISH_REASON) {
+      persistIdleSnapshot(sessionID, now);
+      resetSession(sessionID);
+      return;
+    }
+
+    if (finish && INVALID_FINISH_REASONS.has(finish)) {
+      resetSession(sessionID);
+      clearActiveSnapshot(sessionID);
+      return;
+    }
+
+    const state = sessions.get(sessionID);
+    const stepTokens = settledTokens;
+    const trackedTokens = state?.tracker.getTotalTokens() ?? 0;
+    // Fall back to the streamed heuristic, never to the cumulative session total —
+    // session.usage.updated is a whole-session figure and would wildly overstate one step.
+    const totalTokens = stepTokens > 0 ? stepTokens : trackedTokens;
+    const elapsedMs = state?.firstTokenAt ? Math.max(0, now - state.firstTokenAt) : 0;
+    const avgTps = elapsedMs > 0 ? totalTokens / (elapsedMs / 1000) : 0;
+
+    publishFinal(sessionID, totalTokens, avgTps, elapsedMs, overheadFor(sessionID));
+
+    // Feed the durable rollup. An aborted turn is excluded: its elapsed window is truncated
+    // at an arbitrary point, so folding it in would drag every average down.
+    const turn = metrics.turnOf(sessionID);
+    if (!turn.interrupted && totalTokens > 0) {
+      const attribution = metrics.attributionOf(sessionID);
+      hooks?.onStepSettled?.({
+        sessionID,
+        modelKey: attribution.key,
+        agent: attribution.agent,
+        tokens: totalTokens,
+        generationMs: Math.max(0, elapsedMs - turn.toolMs),
+        cost: typeof event.data.cost === "number" && event.data.cost > 0 ? event.data.cost : 0,
+        ttftMs: turn.ttftMs,
+      });
+    }
+
+    resetSession(sessionID);
+  }
+
+  return {
+    handleEvent(raw: V2UnknownEvent): void {
+      const event = asMeterEvent(raw);
+      if (!event) {
+        return;
+      }
+
+      const now = Date.now();
+      lastActivityAt.set(event.data.sessionID, now);
+      sweepStaleSessions(now);
+
+      switch (event.type) {
+        case "session.text.delta":
+        case "session.reasoning.delta":
+          handleDelta(event);
+          break;
+        case "session.usage.updated":
+          handleUsageUpdated(event);
+          break;
+        case "session.step.started":
+          handleStepStarted(event);
+          break;
+        case "session.tool.called":
+          handleToolCalled(event);
+          break;
+        case "session.tool.success":
+        case "session.tool.failed":
+          handleToolSettled(event);
+          break;
+        case "session.execution.started":
+          handleExecutionStarted(event);
+          break;
+        case "session.execution.succeeded":
+        case "session.execution.failed":
+        case "session.execution.interrupted":
+          handleExecutionSettled(event);
+          break;
+        case "session.step.ended":
+          handleStepEnded(event);
+          break;
+        case "session.idle":
+          persistIdleSnapshot(event.data.sessionID, eventTime(event, Date.now()));
+          resetSession(event.data.sessionID);
+          break;
+      }
+    },
+
+    getSnapshots(): ReadonlyMap<string, V2Snapshot> {
+      return snapshots;
+    },
+
+    subscribe(listener): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    dispose(): void {
+      for (const timer of publishTimers.values()) {
+        clearTimeout(timer);
+      }
+      publishTimers.clear();
+      sessions.clear();
+      streamText.clear();
+      lastActivityAt.clear();
+      sessionUsage.clear();
+      metrics.dispose();
+      listeners.clear();
+      snapshots = new Map();
+      lastSweepAt = 0;
+    },
+  };
+}

--- a/src/v2/metrics.ts
+++ b/src/v2/metrics.ts
@@ -1,0 +1,242 @@
+/**
+ * Tier-2 metrics for OpenCode v2: tokenizer calibration and turn decomposition.
+ *
+ * All of this is impossible on v1, for two structural reasons:
+ *
+ * - v1 events carry no timestamps at all, so tool execution could not be separated from
+ *   model generation and time-to-first-token could not be measured.
+ * - v1's StepStartPart carries neither the model nor the agent, so throughput could not be
+ *   attributed. v2's session.step.started carries both.
+ *
+ * @module v2/metrics
+ */
+
+import type { V2ModelRef } from "./types.js";
+
+/** Calibration is only trusted inside this band; outside it the sample is noise. */
+const MIN_FACTOR = 0.25;
+const MAX_FACTOR = 4;
+/** EWMA weight for a new calibration sample. */
+const CALIBRATION_ALPHA = 0.3;
+/** A step must stream at least this many heuristic tokens before it can calibrate. */
+const MIN_CALIBRATION_TOKENS = 8;
+
+export interface TurnMetrics {
+  /** Milliseconds from turn start to the first streamed token. 0 when unknown. */
+  ttftMs: number;
+  /** Milliseconds spent inside tool execution during this turn. */
+  toolMs: number;
+  /** True when the turn was aborted; its numbers should not be trusted. */
+  interrupted: boolean;
+}
+
+export interface ModelAttribution {
+  /** `providerID/modelID[#variant]`, or "default" before any step.started is seen. */
+  key: string;
+  model?: V2ModelRef;
+  agent?: string;
+}
+
+interface Calibration {
+  factor: number;
+  samples: number;
+}
+
+interface SessionMetrics {
+  turnStartedAt: number | null;
+  firstTokenAt: number | null;
+  toolMs: number;
+  interrupted: boolean;
+  /** Tool callID -> host timestamp when execution began. */
+  runningTools: Map<string, number>;
+  /** Heuristic tokens counted for the current step, for calibration. */
+  stepHeuristicTokens: number;
+  /** Fractional remainder so scaling never silently drops sub-token amounts. */
+  carry: number;
+  attribution: ModelAttribution;
+}
+
+export interface V2Metrics {
+  onExecutionStarted(sessionID: string, at: number): void;
+  onExecutionSettled(sessionID: string, interrupted: boolean): void;
+  onStepStarted(sessionID: string, model: V2ModelRef | undefined, agent: string | undefined): void;
+  onToolCalled(sessionID: string, callID: string, at: number): void;
+  onToolSettled(sessionID: string, callID: string, at: number): void;
+  onFirstToken(sessionID: string, at: number): void;
+  /** Applies the learned factor to a raw heuristic count, carrying the remainder. */
+  scale(sessionID: string, rawTokens: number): number;
+  /** Folds one step's ground truth into the calibration for its model. */
+  calibrate(sessionID: string, realTokens: number): void;
+  turnOf(sessionID: string): TurnMetrics;
+  attributionOf(sessionID: string): ModelAttribution;
+  /** Samples recorded for this session's current model. */
+  samplesOf(sessionID: string): number;
+  resetTurn(sessionID: string): void;
+  forget(sessionID: string): void;
+  dispose(): void;
+}
+
+export function createMetrics(): V2Metrics {
+  const sessions = new Map<string, SessionMetrics>();
+  /** Learned per model, so it survives session churn and benefits every later session. */
+  const calibration = new Map<string, Calibration>();
+
+  function get(sessionID: string): SessionMetrics {
+    let state = sessions.get(sessionID);
+    if (!state) {
+      state = {
+        turnStartedAt: null,
+        firstTokenAt: null,
+        toolMs: 0,
+        interrupted: false,
+        runningTools: new Map(),
+        stepHeuristicTokens: 0,
+        carry: 0,
+        attribution: { key: "default" },
+      };
+      sessions.set(sessionID, state);
+    }
+    return state;
+  }
+
+  function factorFor(key: string): number {
+    return calibration.get(key)?.factor ?? 1;
+  }
+
+  function attributionFor(sessionID: string): ModelAttribution {
+    return sessions.get(sessionID)?.attribution ?? { key: "default" };
+  }
+
+  return {
+    onExecutionStarted(sessionID, at) {
+      const state = get(sessionID);
+      state.turnStartedAt = at;
+      state.firstTokenAt = null;
+      state.toolMs = 0;
+      state.interrupted = false;
+      state.runningTools.clear();
+    },
+
+    onExecutionSettled(sessionID, interrupted) {
+      get(sessionID).interrupted = interrupted;
+    },
+
+    onStepStarted(sessionID, model, agent) {
+      const state = get(sessionID);
+      // A new step resets the calibration accumulator; each step is one closed sample.
+      state.stepHeuristicTokens = 0;
+      state.attribution = {
+        key: model
+          ? `${model.providerID}/${model.id}${model.variant ? `#${model.variant}` : ""}`
+          : state.attribution.key,
+        model: model ?? state.attribution.model,
+        agent: agent ?? state.attribution.agent,
+      };
+    },
+
+    onToolCalled(sessionID, callID, at) {
+      get(sessionID).runningTools.set(callID, at);
+    },
+
+    onToolSettled(sessionID, callID, at) {
+      const state = get(sessionID);
+      const startedAt = state.runningTools.get(callID);
+      if (startedAt === undefined) {
+        return;
+      }
+      state.runningTools.delete(callID);
+      if (at > startedAt) {
+        state.toolMs += at - startedAt;
+      }
+    },
+
+    onFirstToken(sessionID, at) {
+      const state = get(sessionID);
+      if (state.firstTokenAt === null) {
+        state.firstTokenAt = at;
+      }
+    },
+
+    scale(sessionID, rawTokens) {
+      if (rawTokens <= 0) {
+        return 0;
+      }
+      const state = get(sessionID);
+      state.stepHeuristicTokens += rawTokens;
+
+      const factor = factorFor(state.attribution.key);
+      if (factor === 1) {
+        return rawTokens;
+      }
+      const scaled = rawTokens * factor + state.carry;
+      const whole = Math.floor(scaled);
+      state.carry = scaled - whole;
+      return whole;
+    },
+
+    calibrate(sessionID, realTokens) {
+      const state = get(sessionID);
+      const heuristic = state.stepHeuristicTokens;
+      state.stepHeuristicTokens = 0;
+      state.carry = 0;
+
+      if (realTokens <= 0 || heuristic < MIN_CALIBRATION_TOKENS) {
+        return;
+      }
+      const sample = realTokens / heuristic;
+      if (!Number.isFinite(sample) || sample < MIN_FACTOR || sample > MAX_FACTOR) {
+        return;
+      }
+
+      const key = state.attribution.key;
+      const existing = calibration.get(key);
+      if (!existing) {
+        calibration.set(key, { factor: sample, samples: 1 });
+        return;
+      }
+      calibration.set(key, {
+        factor: existing.factor * (1 - CALIBRATION_ALPHA) + sample * CALIBRATION_ALPHA,
+        samples: existing.samples + 1,
+      });
+    },
+
+    turnOf(sessionID) {
+      const state = sessions.get(sessionID);
+      if (!state) {
+        return { ttftMs: 0, toolMs: 0, interrupted: false };
+      }
+      const ttftMs =
+        state.turnStartedAt !== null && state.firstTokenAt !== null
+          ? Math.max(0, state.firstTokenAt - state.turnStartedAt)
+          : 0;
+      return { ttftMs, toolMs: state.toolMs, interrupted: state.interrupted };
+    },
+
+    attributionOf: attributionFor,
+
+    // Deliberately closes over `attributionFor` rather than using `this`, so the method
+    // keeps working if a caller destructures it off the object.
+    samplesOf(sessionID) {
+      return calibration.get(attributionFor(sessionID).key)?.samples ?? 0;
+    },
+
+    resetTurn(sessionID) {
+      const state = sessions.get(sessionID);
+      if (!state) {
+        return;
+      }
+      state.stepHeuristicTokens = 0;
+      state.carry = 0;
+      state.runningTools.clear();
+    },
+
+    forget(sessionID) {
+      sessions.delete(sessionID);
+    },
+
+    dispose() {
+      sessions.clear();
+      calibration.clear();
+    },
+  };
+}

--- a/src/v2/server.ts
+++ b/src/v2/server.ts
@@ -1,0 +1,165 @@
+/**
+ * OpenCode v2 server plugin entry.
+ *
+ * Scope note: unlike v1, the v2 server context exposes no UI surface — there is no
+ * `client`, no toast API, and no way to publish TUI events from a server plugin. The
+ * meter therefore renders exclusively from the v2 TUI entry (src/v2/tui.tsx); this entry
+ * exists so the package registers cleanly under v2's `plugins` array, and so measurements
+ * only reachable below the streaming pipeline are available to embedders and tests.
+ *
+ * The v1 `toastFallback` option has no effect here.
+ *
+ * @module v2/server
+ */
+
+import { defaultConfig, loadConfigSync } from "../config.js";
+import type { Config } from "../types.js";
+import { createMeter, type V2Meter, type V2Snapshot } from "./meter.js";
+import type {
+  V2Cleanup,
+  V2HttpHookInput,
+  V2PluginDefinition,
+  V2ServerContext,
+  V2UnknownEvent,
+} from "./types.js";
+
+/** Snapshots tracked by the most recent server setup, for embedders and tests. */
+let activeMeter: V2Meter | null = null;
+
+/**
+ * Wire-level latency per session.
+ *
+ * This is strictly below what the TUI can see. `session.text.delta` timing includes the
+ * provider's queueing plus OpenCode's own streaming pipeline; the HTTP hooks measure the
+ * request-dispatch to response-headers gap directly, which is the true network + queue
+ * cost. v1 had no equivalent hook.
+ */
+export interface WireTiming {
+  /** Milliseconds from provider request dispatch to response headers. */
+  ttfbMs: number;
+  /** Requests measured this session. */
+  samples: number;
+  providerID?: string;
+}
+
+const wireTimings = new Map<string, WireTiming>();
+
+/** Current per-session readings, or an empty map when the plugin is not running. */
+export function getSnapshots(): ReadonlyMap<string, V2Snapshot> {
+  return activeMeter?.getSnapshots() ?? new Map<string, V2Snapshot>();
+}
+
+/**
+ * Wire-level timings observed by the server half.
+ *
+ * NOTE: server and TUI are separate processes with no shared memory, so these numbers
+ * cannot reach the on-screen meter as things stand. They are exposed for embedders and for
+ * the day a plugin-owned channel between the two halves exists.
+ */
+export function getWireTimings(): ReadonlyMap<string, WireTiming> {
+  return wireTimings;
+}
+
+function loadServerConfig(options?: Readonly<Record<string, unknown>>): Config {
+  try {
+    return loadConfigSync(options as Partial<Config> | undefined);
+  } catch {
+    return defaultConfig;
+  }
+}
+
+/**
+ * v2 server setup. Returns a cleanup function; v2 calls it on disable, reload, and shutdown.
+ */
+export function setupServer(ctx: V2ServerContext): V2Cleanup | void {
+  const config = loadServerConfig(ctx.options);
+  if (!config.enabled) {
+    return;
+  }
+
+  const meter = createMeter(config);
+  activeMeter = meter;
+
+  // v2 delivers events as an async iterable rather than v1's callback hook, so the
+  // stream is drained on its own task and stopped via AbortSignal on cleanup.
+  const controller = new AbortController();
+
+  void (async () => {
+    try {
+      for await (const event of ctx.event.subscribe({ signal: controller.signal })) {
+        if (controller.signal.aborted) {
+          break;
+        }
+        meter.handleEvent(event as V2UnknownEvent);
+      }
+    } catch {
+      // Stream ended or was aborted during shutdown; nothing to recover.
+    }
+  })();
+
+  // Wire-level TTFB. Both hook bodies are one-shot streams — reading either would consume
+  // the payload out from under the provider — so only timestamps are taken here.
+  const dispatchedAt = new Map<string, number>();
+
+  if (ctx.session?.hook) {
+    try {
+      ctx.session.hook("http.request", (input: V2HttpHookInput) => {
+        const sessionID = input?.sessionID;
+        if (typeof sessionID === "string" && sessionID.length > 0) {
+          dispatchedAt.set(sessionID, Date.now());
+        }
+      });
+
+      ctx.session.hook("http.response", (input: V2HttpHookInput) => {
+        const sessionID = input?.sessionID;
+        if (typeof sessionID !== "string" || sessionID.length === 0) {
+          return;
+        }
+        const started = dispatchedAt.get(sessionID);
+        if (started === undefined) {
+          return;
+        }
+        dispatchedAt.delete(sessionID);
+
+        const elapsed = Date.now() - started;
+        if (elapsed < 0) {
+          return;
+        }
+        const existing = wireTimings.get(sessionID);
+        if (!existing) {
+          wireTimings.set(sessionID, {
+            ttfbMs: elapsed,
+            samples: 1,
+            providerID: input?.providerID,
+          });
+          return;
+        }
+        wireTimings.set(sessionID, {
+          ttfbMs: (existing.ttfbMs * existing.samples + elapsed) / (existing.samples + 1),
+          samples: existing.samples + 1,
+          providerID: input?.providerID ?? existing.providerID,
+        });
+      });
+    } catch {
+      // The hook API is beta; a signature change must not take the whole plugin down.
+    }
+  }
+
+  return () => {
+    controller.abort();
+    meter.dispose();
+    dispatchedAt.clear();
+    wireTimings.clear();
+    if (activeMeter === meter) {
+      activeMeter = null;
+    }
+  };
+}
+
+/** v2 server plugin definition. Structurally what `Plugin.define` from `@opencode-ai/plugin` returns. */
+export const v2ServerPlugin: V2PluginDefinition<V2ServerContext> = {
+  id: "opencode-tps-meter",
+  setup: setupServer,
+};
+
+export default v2ServerPlugin;

--- a/src/v2/tui.tsx
+++ b/src/v2/tui.tsx
@@ -431,7 +431,13 @@ export function setupTui(ctx: V2TuiContext): V2Cleanup | void {
   // guard, so a failure in an optional surface below can never cost us the meter itself.
   disposers.push(
     ctx.ui.slot({
-      append: "prompt.footer.status",
+      // PREPEND, not append. The host's own child in this slot is a box with flexGrow:1,
+      // and while a turn is running it renders a second flexGrow:1 box holding the spinner
+      // and the "esc interrupt" hint. Appending puts the meter after that greedy box, so it
+      // is squeezed to zero width the moment anything runs — thinking, tool calls, or
+      // compaction — and only reappears when the session goes idle. Prepending lays the
+      // meter out first, and MeterView's flexShrink={0} keeps its width.
+      prepend: "prompt.footer.status",
       render: (input) => (
         <MeterView
           input={input}

--- a/src/v2/tui.tsx
+++ b/src/v2/tui.tsx
@@ -431,13 +431,16 @@ export function setupTui(ctx: V2TuiContext): V2Cleanup | void {
   // guard, so a failure in an optional surface below can never cost us the meter itself.
   disposers.push(
     ctx.ui.slot({
-      // PREPEND, not append. The host's own child in this slot is a box with flexGrow:1,
-      // and while a turn is running it renders a second flexGrow:1 box holding the spinner
-      // and the "esc interrupt" hint. Appending puts the meter after that greedy box, so it
-      // is squeezed to zero width the moment anything runs — thinking, tool calls, or
-      // compaction — and only reappears when the session goes idle. Prepending lays the
-      // meter out first, and MeterView's flexShrink={0} keeps its width.
-      prepend: "prompt.footer.status",
+      // AFTER, not append. The host's own child inside prompt.footer.status is a box with
+      // flexGrow:1, and while a turn is running it renders a second flexGrow:1 box holding
+      // the spinner and the "esc interrupt" hint. Appending places the meter INSIDE that
+      // boundary, after the greedy child, so it collapses to zero width the moment anything
+      // runs — thinking, tool calls, or compaction — and only reappears once idle.
+      //
+      // `after` makes the meter a SIBLING of the status box rather than a child, so the
+      // greedy layout cannot reach it, while the box's flexGrow:1 still pushes the meter to
+      // the right of the spinner. MeterView's flexShrink={0} holds its width.
+      after: "prompt.footer.status",
       render: (input) => (
         <MeterView
           input={input}

--- a/src/v2/tui.tsx
+++ b/src/v2/tui.tsx
@@ -1,0 +1,522 @@
+/**
+ * OpenCode v2 TUI plugin — the persistent TPS meter for `opencode2`.
+ *
+ * Differences from the v1 TUI entry (src/tui.tsx):
+ *
+ *   v1 `{ id, tui(api, options, meta) }`   -> v2 `{ id, setup(ctx) }`
+ *   v1 `api.slots.register({ slots })`     -> v2 `ctx.ui.slot(claim)`
+ *   v1 slot `session_prompt_right`         -> v2 `prompt.footer.status`
+ *   v1 `props.session_id` (required)       -> v2 `input.sessionID` (optional)
+ *   v1 `api.event.on`                      -> v2 `ctx.data.on`
+ *   v1 `api.theme.current.<token>`         -> v2 `ctx.theme.text.<token>`
+ *   v1 `api.lifecycle.onDispose(fn)`       -> v2 return cleanup from `setup`
+ *
+ * Surfaces beyond v1's single status string: a sidebar panel breaking throughput down per
+ * subagent, a full-screen dashboard over the durable ledger, and palette/slash commands.
+ *
+ * @module v2/tui
+ */
+
+import { createMemo, createSignal, For, Show } from "solid-js";
+import { defaultConfig, loadConfigSync } from "../config.js";
+import { formatMeterText } from "../format.js";
+import type { Config } from "../types.js";
+import { createMeter, type V2Snapshot } from "./meter.js";
+import { createLedger, type V2Ledger } from "./ledger.js";
+import type {
+  V2AnyMeterEvent,
+  V2Cleanup,
+  V2KeymapLayer,
+  V2PluginDefinition,
+  V2ResolvedTheme,
+  V2Rgba,
+  V2SlotInput,
+  V2TuiContext,
+  V2UnknownEvent,
+} from "./types.js";
+
+/** Events the TUI plugin subscribes to. */
+const SUBSCRIBED_EVENTS: ReadonlyArray<V2AnyMeterEvent["type"]> = [
+  "session.text.delta",
+  "session.reasoning.delta",
+  "session.step.ended",
+  "session.usage.updated",
+  "session.idle",
+  "session.step.started",
+  "session.tool.called",
+  "session.tool.success",
+  "session.tool.failed",
+  "session.execution.started",
+  "session.execution.succeeded",
+  "session.execution.failed",
+  "session.execution.interrupted",
+];
+
+/** How much the footer meter shows. Cycled by the `/tps` command. */
+type DisplayMode = "compact" | "detailed" | "hidden";
+
+const MODE_ORDER: readonly DisplayMode[] = ["compact", "detailed", "hidden"];
+
+/** Route name for the dashboard page. */
+const DASHBOARD_ROUTE = "tps";
+
+function loadTuiConfig(options?: Readonly<Record<string, unknown>>): Config {
+  try {
+    return loadConfigSync(options as Partial<Config> | undefined);
+  } catch {
+    return defaultConfig;
+  }
+}
+
+function tps(value: number): string {
+  return value.toFixed(1);
+}
+
+function ms(value: number): string {
+  return value >= 1000 ? `${(value / 1000).toFixed(1)}s` : `${Math.round(value)}ms`;
+}
+
+/**
+ * Maps a reading onto v2's nested theme tokens.
+ * v1's flat `error`/`warning`/`success` moved under `text.feedback.<kind>.default`,
+ * and `textMuted` became `text.subdued`.
+ */
+function colorForSnapshot(
+  theme: V2ResolvedTheme,
+  config: Config,
+  snapshot: V2Snapshot
+): V2Rgba {
+  if (!snapshot.active) {
+    return theme.text.subdued;
+  }
+  if (!config.enableColorCoding) {
+    return theme.text.default;
+  }
+  if (snapshot.instantTps < config.slowTpsThreshold) {
+    return theme.text.feedback.error.default;
+  }
+  if (snapshot.instantTps > config.fastTpsThreshold) {
+    return theme.text.feedback.success.default;
+  }
+  return theme.text.feedback.warning.default;
+}
+
+function MeterView(props: {
+  input: V2SlotInput;
+  theme: V2ResolvedTheme;
+  config: Config;
+  mode: () => DisplayMode;
+  snapshots: () => ReadonlyMap<string, V2Snapshot>;
+}) {
+  // sessionID is optional in v2 — the footer also renders on surfaces with no session.
+  const current = createMemo(() => {
+    if (props.mode() === "hidden") {
+      return undefined;
+    }
+    const sessionID = props.input.sessionID;
+    return sessionID ? props.snapshots().get(sessionID) : undefined;
+  });
+
+  const line = createMemo(() => {
+    const snapshot = current();
+    if (!snapshot) {
+      return "";
+    }
+    const base = formatMeterText(snapshot, props.config);
+    if (props.mode() !== "detailed") {
+      return base;
+    }
+    const extra: string[] = [];
+    // generationTps only differs from the headline once tool time has been subtracted.
+    if (snapshot.toolMs > 0) {
+      extra.push(`gen ${tps(snapshot.generationTps)}`);
+    }
+    if (snapshot.ttftMs > 0) {
+      extra.push(`ttft ${ms(snapshot.ttftMs)}`);
+    }
+    if (snapshot.overheadTokens > 0) {
+      extra.push(`+${snapshot.overheadTokens} ovh`);
+    }
+    if (snapshot.interrupted) {
+      extra.push("aborted");
+    }
+    return extra.length > 0 ? `${base} · ${extra.join(" · ")}` : base;
+  });
+
+  return (
+    <Show when={current()} fallback={<box flexShrink={0} />}>
+      {(snapshot) => (
+        <box flexDirection="row" flexShrink={0}>
+          <text fg={colorForSnapshot(props.theme, props.config, snapshot())}>{line()}</text>
+        </box>
+      )}
+    </Show>
+  );
+}
+
+interface FamilyRow {
+  id: string;
+  label: string;
+  isRoot: boolean;
+  running: boolean;
+  tps: number;
+  tokens: number;
+}
+
+/**
+ * Per-subagent throughput, rendered in the session sidebar.
+ *
+ * v1 had to guess at subagent relationships by comparing session IDs against a heuristically
+ * chosen "primary" session (see src/index.ts). v2 exposes the real tree via
+ * `ctx.data.session.root` / `.family`, so attribution is exact rather than inferred.
+ */
+function SidebarPanel(props: {
+  input: V2SlotInput;
+  ctx: V2TuiContext;
+  theme: V2ResolvedTheme;
+  snapshots: () => ReadonlyMap<string, V2Snapshot>;
+}) {
+  // Split deliberately: the session tree and each agent's name change rarely, while
+  // snapshots change on every token publish (up to ~125/s). Resolving the family inside the
+  // snapshot-dependent memo re-ran root/family/get for every row on every publish.
+  const family = createMemo<Array<{ id: string; label: string; isRoot: boolean }>>(() => {
+    const data = props.ctx.data.session;
+    const sessionID = props.input.sessionID;
+    if (!data || !sessionID) {
+      return [];
+    }
+    let rootID: string;
+    let ids: string[];
+    try {
+      rootID = data.root(sessionID);
+      ids = data.family(rootID) ?? [];
+    } catch {
+      return [];
+    }
+    // A solo session is already covered by the footer meter; only show the breakdown
+    // once work has actually fanned out.
+    if (ids.length <= 1) {
+      return [];
+    }
+    return ids.map((id) => ({
+      id,
+      label: data.get(id)?.agent ?? (id === rootID ? "main" : id.slice(-6)),
+      isRoot: id === rootID,
+    }));
+  });
+
+  const rows = createMemo<FamilyRow[]>(() => {
+    const members = family();
+    if (members.length === 0) {
+      return [];
+    }
+    const data = props.ctx.data.session;
+    const snaps = props.snapshots();
+    return members.map((member) => {
+      const snapshot = snaps.get(member.id);
+      return {
+        ...member,
+        running: data?.status(member.id) === "running",
+        tps: snapshot ? (snapshot.active ? snapshot.instantTps : snapshot.avgTps) : 0,
+        tokens: snapshot?.totalTokens ?? 0,
+      };
+    });
+  });
+
+  return (
+    <Show when={rows().length > 0} fallback={<box flexShrink={0} />}>
+      <box flexDirection="column" flexShrink={0}>
+        <text fg={props.theme.text.subdued}>Throughput</text>
+        <For each={rows()}>
+          {(row) => (
+            <box flexDirection="row" flexShrink={0}>
+              <text fg={row.running ? props.theme.text.default : props.theme.text.subdued}>
+                {`${row.isRoot ? ">" : " "} ${row.label} ${tps(row.tps)} t/s ${row.tokens} tok`}
+              </text>
+            </box>
+          )}
+        </For>
+      </box>
+    </Show>
+  );
+}
+
+/**
+ * Full-screen dashboard over the durable ledger.
+ *
+ * Everything here outlives the TUI process and is shared across windows, which is only
+ * possible because of `ctx.storage.store`.
+ */
+function DashboardPage(props: {
+  ledger: V2Ledger;
+  theme: V2ResolvedTheme;
+  snapshots: () => ReadonlyMap<string, V2Snapshot>;
+}) {
+  const models = createMemo(() => {
+    const data = props.ledger.read();
+    return Object.entries(data.models ?? {})
+      .map(([key, entry]) => ({
+        key,
+        entry,
+        meanTps: entry.generationMs > 0 ? entry.tokens / (entry.generationMs / 1000) : 0,
+      }))
+      .sort((a, b) => b.meanTps - a.meanTps);
+  });
+
+  const live = createMemo(() => [...props.snapshots().values()].filter((s) => s.active));
+
+  const header =
+    "model".padEnd(34) +
+    "mean".padStart(8) +
+    "best".padStart(8) +
+    "ttft".padStart(9) +
+    "n".padStart(6);
+
+  return (
+    <box flexDirection="column" flexGrow={1}>
+      <text fg={props.theme.text.default}>Throughput dashboard</text>
+
+      <Show when={live().length > 0}>
+        <box flexDirection="column" flexShrink={0}>
+          <text fg={props.theme.text.subdued}>Live</text>
+          <For each={live()}>
+            {(s) => (
+              <text fg={props.theme.text.default}>
+                {`  ${s.modelKey}  ${tps(s.instantTps)} t/s  gen ${tps(s.generationTps)}  ${s.totalTokens} tok`}
+              </text>
+            )}
+          </For>
+        </box>
+      </Show>
+
+      <text fg={props.theme.text.subdued}>{header}</text>
+      <Show
+        when={models().length > 0}
+        fallback={<text fg={props.theme.text.subdued}>  no completed steps recorded yet</text>}
+      >
+        <For each={models()}>
+          {(row) => (
+            <text fg={props.theme.text.default}>
+              {row.key.slice(0, 33).padEnd(34) +
+                tps(row.meanTps).padStart(8) +
+                tps(row.entry.bestTps).padStart(8) +
+                (row.entry.ttftSamples > 0 ? ms(row.entry.meanTtftMs) : "-").padStart(9) +
+                String(row.entry.samples).padStart(6)}
+            </text>
+          )}
+        </For>
+      </Show>
+    </box>
+  );
+}
+
+/**
+ * Registers the plugin's commands.
+ *
+ * `ctx.keymap.layer` creates a layer owned by the CALLING COMPONENT, so it cannot be invoked
+ * from bare `setup` — it needs a reactive owner. Mounting a null-rendering component in the
+ * `app` slot is the pattern the host's own built-in plugins use for exactly this.
+ */
+function CommandLayer(props: {
+  ctx: V2TuiContext;
+  mode: () => DisplayMode;
+  setMode: (next: DisplayMode) => void;
+  snapshots: () => ReadonlyMap<string, V2Snapshot>;
+  ledger: V2Ledger;
+}) {
+  const describe = (): string => {
+    const entries = [...props.snapshots().values()];
+    if (entries.length === 0) {
+      return "No throughput recorded yet.";
+    }
+    return entries
+      .map((s) => {
+        const parts = [`${tps(s.active ? s.instantTps : s.avgTps)} TPS`, `${s.totalTokens} tok`];
+        if (s.toolMs > 0) parts.push(`gen ${tps(s.generationTps)}`);
+        if (s.ttftMs > 0) parts.push(`ttft ${ms(s.ttftMs)}`);
+        if (s.overheadTokens > 0) parts.push(`+${s.overheadTokens} overhead`);
+        return parts.join(" · ");
+      })
+      .join(" | ");
+  };
+
+  const layer = (): V2KeymapLayer => ({
+    mode: "global",
+    commands: [
+      {
+        id: "tps.toggle",
+        title: "Throughput meter",
+        description: "Open the dashboard, cycle the meter, or show current stats",
+        group: "TPS Meter",
+        palette: true,
+        slash: { name: "tps", arguments: true },
+        run: (input?: string) => {
+          const arg = (input ?? "").trim().toLowerCase();
+
+          if (arg === "" && props.ctx.ui.router) {
+            props.ctx.ui.router.navigate({ type: "plugin", name: DASHBOARD_ROUTE });
+            return;
+          }
+          if (arg === "detail" || arg === "details") {
+            props.ctx.ui.toast?.show({
+              title: "Throughput",
+              message: describe(),
+              variant: "info",
+              duration: 6000,
+            });
+            return;
+          }
+          if (arg === "reset") {
+            props.ledger.clear();
+            props.ctx.ui.toast?.show({
+              title: "Throughput",
+              message: "Ledger cleared.",
+              variant: "success",
+            });
+            return;
+          }
+          if (arg === "compact" || arg === "detailed" || arg === "hidden") {
+            props.setMode(arg as DisplayMode);
+            return;
+          }
+          const index = MODE_ORDER.indexOf(props.mode());
+          props.setMode(MODE_ORDER[(index + 1) % MODE_ORDER.length] as DisplayMode);
+        },
+      },
+    ],
+  });
+
+  try {
+    props.ctx.keymap?.layer(layer);
+  } catch {
+    // Command registration is a nicety; the meter matters more.
+  }
+  return null;
+}
+
+/**
+ * v2 TUI setup. Returns a cleanup function; v2 calls it on disable, reload, and shutdown.
+ */
+export function setupTui(ctx: V2TuiContext): V2Cleanup | void {
+  const config = loadTuiConfig(ctx.options);
+  if (!config.enabled) {
+    return;
+  }
+
+  const ledger = createLedger(ctx.storage);
+  const meter = createMeter(config, {
+    onStepSettled: (measurement) => {
+      try {
+        ledger.record(measurement);
+      } catch {
+        // A durable-store failure must never interrupt metering.
+      }
+    },
+  });
+  const [snapshots, setSnapshots] = createSignal<ReadonlyMap<string, V2Snapshot>>(new Map());
+  const [mode, setMode] = createSignal<DisplayMode>("compact");
+  const disposers: Array<() => void> = [];
+
+  disposers.push(meter.subscribe((next) => setSnapshots(() => next)));
+
+  for (const type of SUBSCRIBED_EVENTS) {
+    disposers.push(
+      ctx.data.on(type, (event) => {
+        meter.handleEvent(event as unknown as V2UnknownEvent);
+      })
+    );
+  }
+
+  // The footer meter is the ONE surface that must exist. It is claimed first and outside any
+  // guard, so a failure in an optional surface below can never cost us the meter itself.
+  disposers.push(
+    ctx.ui.slot({
+      append: "prompt.footer.status",
+      render: (input) => (
+        <MeterView
+          input={input}
+          theme={ctx.theme}
+          config={config}
+          mode={mode}
+          snapshots={snapshots}
+        />
+      ),
+    })
+  );
+
+  /**
+   * Registers an optional surface.
+   *
+   * These APIs are beta and typed structurally in src/v2/types.ts — presence does not
+   * guarantee the signature matches. Previously a throw here aborted `setup`, which the host
+   * treats as a failed plugin load: one bad optional call and the user gets NO meter at all,
+   * with nothing in the log because TUI plugin failures are silent.
+   */
+  function optional(label: string, register: () => (() => void) | undefined): void {
+    try {
+      const dispose = register();
+      if (typeof dispose === "function") {
+        disposers.push(dispose);
+      }
+    } catch {
+      // Degrade to the footer meter; `label` is retained for future diagnostics.
+      void label;
+    }
+  }
+
+  // Per-subagent breakdown. Only renders when the session actually has a family.
+  if (ctx.data.session) {
+    optional("sidebar", () =>
+      ctx.ui.slot({
+        append: "sidebar.content",
+        render: (input) => (
+          <SidebarPanel input={input} ctx={ctx} theme={ctx.theme} snapshots={snapshots} />
+        ),
+      })
+    );
+  }
+
+  if (ctx.ui.router) {
+    optional("dashboard", () =>
+      ctx.ui.router?.register({
+        name: DASHBOARD_ROUTE,
+        render: () => <DashboardPage ledger={ledger} theme={ctx.theme} snapshots={snapshots} />,
+      })
+    );
+  }
+
+  // Commands need a reactive owner; the `app` slot provides one without drawing anything.
+  if (ctx.keymap) {
+    optional("commands", () =>
+      ctx.ui.slot({
+        append: "app",
+        render: () => (
+          <CommandLayer
+            ctx={ctx}
+            mode={mode}
+            setMode={setMode}
+            snapshots={snapshots}
+            ledger={ledger}
+          />
+        ),
+      })
+    );
+  }
+
+  return () => {
+    for (const dispose of disposers) {
+      dispose();
+    }
+    disposers.length = 0;
+    meter.dispose();
+    setSnapshots(() => new Map<string, V2Snapshot>());
+  };
+}
+
+/** v2 TUI plugin definition. Structurally what `Plugin.define` from `@opencode-ai/plugin/tui` returns. */
+export const v2TuiPlugin: V2PluginDefinition<V2TuiContext> = {
+  id: "opencode-tps-meter",
+  setup: setupTui,
+};
+
+export default v2TuiPlugin;

--- a/src/v2/types.ts
+++ b/src/v2/types.ts
@@ -1,0 +1,419 @@
+/**
+ * Structural type definitions for the OpenCode v2 (`opencode2`) plugin surface.
+ *
+ * These mirror `@opencode-ai/plugin@next` (verified against 0.0.0-next-17293) but are
+ * declared locally on purpose:
+ *
+ * - v1 and v2 types ship under the same package name, so both cannot be installed at once
+ *   while this package still supports v1.
+ * - The v2 API is beta and explicitly documented as subject to change; structural types keep
+ *   a churning upstream from breaking our build.
+ *
+ * Only the members this plugin actually consumes are declared.
+ *
+ * @module v2/types
+ */
+
+import type { RGBA } from "@opentui/core";
+
+/** Workspace/directory a v2 event originated from. */
+export interface V2LocationRef {
+  directory: string;
+  workspaceID?: string;
+}
+
+/** Common envelope shared by every v2 event. */
+export interface V2Envelope<Type extends string, Data> {
+  id: string;
+  created: number;
+  type: Type;
+  location?: V2LocationRef;
+  data: Data;
+}
+
+/** Provider-reported token usage, attached to step and usage events. */
+export interface V2TokenUsage {
+  input: number;
+  output: number;
+  reasoning: number;
+  cache: {
+    read: number;
+    write: number;
+  };
+}
+
+/**
+ * Finish reasons reported by `session.step.ended`.
+ * Same vocabulary as v1's `message.updated` `info.finish`, so the existing
+ * INVALID_FINISH_REASONS / TOOL_CALL_FINISH_REASON constants apply unchanged.
+ */
+export type V2FinishReason =
+  | "stop"
+  | "length"
+  | "tool-calls"
+  | "content-filter"
+  | "error"
+  | "unknown";
+
+/** Streaming assistant text chunk. Replaces v1 `message.part.delta` (field === "text"). */
+export type V2SessionTextDelta = V2Envelope<
+  "session.text.delta",
+  {
+    sessionID: string;
+    assistantMessageID: string;
+    ordinal: number;
+    delta: string;
+  }
+>;
+
+/** Streaming assistant reasoning chunk. */
+export type V2SessionReasoningDelta = V2Envelope<
+  "session.reasoning.delta",
+  {
+    sessionID: string;
+    assistantMessageID: string;
+    ordinal: number;
+    delta: string;
+  }
+>;
+
+/** A model step finished. Replaces v1 `message.updated` with `info.time.completed`. */
+export type V2SessionStepEnded = V2Envelope<
+  "session.step.ended",
+  {
+    sessionID: string;
+    assistantMessageID: string;
+    finish: V2FinishReason;
+    cost: number;
+    tokens: V2TokenUsage;
+  }
+>;
+
+/** Cumulative session usage. Used as a fallback when a step reports no tokens. */
+export type V2SessionUsageUpdated = V2Envelope<
+  "session.usage.updated",
+  {
+    sessionID: string;
+    cost: number;
+    tokens: V2TokenUsage;
+  }
+>;
+
+/** Session went idle. Carried over from v1 unchanged. */
+export type V2SessionIdle = V2Envelope<"session.idle", { sessionID: string }>;
+
+/** Union of every event this plugin subscribes to. */
+export type V2MeterEvent =
+  | V2SessionTextDelta
+  | V2SessionReasoningDelta
+  | V2SessionStepEnded
+  | V2SessionUsageUpdated
+  | V2SessionIdle;
+
+/** Any v2 event; narrowed to V2MeterEvent before use. */
+export interface V2UnknownEvent {
+  type: string;
+  data?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+// =============================================================================
+// Server plugin context (`@opencode-ai/plugin`)
+// =============================================================================
+
+/**
+ * v2 server plugin context.
+ *
+ * Note `event.subscribe()` returns an AsyncIterable, not a callback registration —
+ * a deliberate difference from both v1's `event` hook and v2's TUI `data.on`.
+ */
+export interface V2ServerContext {
+  readonly app?: {
+    readonly name: string;
+    readonly version: string;
+    readonly channel: string;
+  };
+  readonly options?: Readonly<Record<string, unknown>>;
+  readonly event: {
+    readonly subscribe: (
+      requestOptions?: { signal?: AbortSignal }
+    ) => AsyncIterable<V2UnknownEvent>;
+  };
+  /**
+   * Provider-dispatch hooks. `http.response` fires when response HEADERS arrive, which is
+   * the only place a true wire-level time-to-first-byte can be measured — it sits below the
+   * streaming pipeline the TUI observes. v1 exposed nothing comparable.
+   */
+  readonly session?: {
+    readonly hook: (
+      name: "http.request" | "http.response",
+      callback: (input: V2HttpHookInput) => void | Promise<void>
+    ) => unknown;
+  };
+}
+
+/** Payload handed to the provider HTTP hooks. */
+export interface V2HttpHookInput {
+  readonly sessionID?: string;
+  readonly providerID?: string;
+  /** Present on http.request. Body is a one-shot stream: never read it here. */
+  readonly request?: unknown;
+  /** Present on http.response. Body is a one-shot stream: never read it here. */
+  readonly response?: unknown;
+}
+
+/** Cleanup returned from a v2 `setup` function. */
+export type V2Cleanup = () => Promise<void> | void;
+
+/** Shape both v2 server and v2 TUI plugin modules must satisfy. */
+export interface V2PluginDefinition<Context> {
+  readonly id: string;
+  readonly setup: (context: Context) => Promise<V2Cleanup | void> | V2Cleanup | void;
+}
+
+// =============================================================================
+// TUI plugin context (`@opencode-ai/plugin/tui`)
+// =============================================================================
+
+/** An `@opentui/core` RGBA colour value. v2 theme tokens resolve to these. */
+export type V2Rgba = RGBA;
+
+/** Resolved theme token subset used by the meter. Replaces v1's flat `theme.current`. */
+export interface V2ResolvedTheme {
+  readonly text: {
+    readonly default: V2Rgba;
+    readonly subdued: V2Rgba;
+    readonly feedback: Readonly<
+      Record<"error" | "warning" | "success" | "info", { readonly default: V2Rgba }>
+    >;
+  };
+}
+
+/** Reactive props published by the `prompt.footer.*` slots. */
+export interface V2PromptFooterInput {
+  readonly sessionID?: string;
+  readonly mode: "normal" | "shell";
+}
+
+/**
+ * Slot paths published by the v2 TUI host.
+ * v1's `session_prompt_right` has no direct successor; `prompt.footer.status` is the
+ * status region beside the prompt and is the closest equivalent.
+ */
+export type V2SlotPath =
+  | "app"
+  | "home.footer"
+  | "prompt.footer"
+  | "prompt.footer.status"
+  | "prompt.footer.file"
+  | "session.composer.top"
+  | "sidebar.content"
+  | "sidebar.footer";
+
+/**
+ * Reactive input a slot publishes. Paths differ in what they carry: `prompt.footer.*` gives
+ * an optional sessionID plus the prompt mode, while `sidebar.content` gives a required
+ * sessionID and no mode. The union covers both.
+ */
+export interface V2SlotInput {
+  readonly sessionID?: string;
+  readonly mode?: "normal" | "shell";
+}
+
+/** One contribution to the v2 slot tree. */
+export interface V2SlotClaim {
+  readonly render: (input: V2SlotInput) => unknown;
+  readonly append?: V2SlotPath;
+  readonly prepend?: V2SlotPath;
+  readonly before?: V2SlotPath;
+  readonly after?: V2SlotPath;
+  readonly replace?: V2SlotPath;
+}
+
+/** A command contributed to the palette, slash completion, and keybindings. */
+export interface V2KeymapCommand {
+  readonly id?: string;
+  readonly title?: string;
+  readonly description?: string;
+  readonly group?: string;
+  readonly palette?: true;
+  readonly slash?: {
+    readonly name: string;
+    readonly aliases?: string[];
+    readonly arguments?: true;
+  };
+  readonly bind?: false | string;
+  readonly enabled?: boolean | (() => boolean);
+  readonly run: (input?: string) => void | false | Promise<void>;
+}
+
+/** A reactive keymap layer. Must be registered from inside a reactive owner. */
+export interface V2KeymapLayer {
+  readonly mode?: string;
+  readonly enabled?: boolean | (() => boolean);
+  readonly priority?: number;
+  readonly commands?: readonly V2KeymapCommand[];
+  readonly bindings?: readonly string[];
+}
+
+export type V2ToastVariant = "info" | "success" | "warning" | "error";
+
+/** v2 TUI plugin context. */
+export interface V2TuiContext {
+  readonly options?: Readonly<Record<string, unknown>>;
+  readonly theme: V2ResolvedTheme;
+  readonly data: {
+    readonly on: <Type extends V2AnyMeterEvent["type"]>(
+      type: Type,
+      handler: (event: Extract<V2AnyMeterEvent, { type: Type }>) => void
+    ) => () => void;
+    /** Synced session metadata. Replaces v1's parentID-sniffing for subagent attribution. */
+    readonly session?: V2SessionData;
+  };
+  readonly ui: {
+    readonly slot: (claim: V2SlotClaim) => () => void;
+    readonly router?: V2Router;
+    readonly toast?: {
+      readonly show: (options: {
+        readonly title?: string;
+        readonly message: string;
+        readonly variant?: V2ToastVariant;
+        readonly duration?: number;
+      }) => void;
+    };
+  };
+  /**
+   * Reactive keymap. `layer` is owned by the calling component, so it must be invoked from
+   * inside a rendered component rather than from bare `setup`.
+   */
+  readonly keymap?: {
+    readonly layer: (input: () => V2KeymapLayer) => void;
+  };
+  /** Durable + ephemeral plugin state. No v1 equivalent. */
+  readonly storage?: V2Storage;
+}
+
+// =============================================================================
+// Extended surface (Tier 2/3): attribution, turn decomposition, storage, routing
+// =============================================================================
+
+/** Model reference carried by step and selection events. */
+export interface V2ModelRef {
+  readonly id: string;
+  readonly providerID: string;
+  readonly variant?: string;
+}
+
+/**
+ * A model step began.
+ *
+ * Carries the agent and model that produced the step — v1's StepStartPart carried neither,
+ * which is why v1 could not attribute throughput to a model or agent.
+ */
+export type V2SessionStepStarted = V2Envelope<
+  "session.step.started",
+  {
+    sessionID: string;
+    assistantMessageID: string;
+    agent?: string;
+    model?: V2ModelRef;
+  }
+>;
+
+/** The model began generating a tool call's arguments. */
+export type V2SessionToolInputStarted = V2Envelope<
+  "session.tool.input.started",
+  { sessionID: string; assistantMessageID?: string; id: string; name?: string }
+>;
+
+/** Tool execution began (host stamps time.ran from this event's `created`). */
+export type V2SessionToolCalled = V2Envelope<
+  "session.tool.called",
+  { sessionID: string; id: string; name?: string; executed?: boolean }
+>;
+
+/** Tool execution ended, successfully or not. */
+export type V2SessionToolSettled = V2Envelope<
+  "session.tool.success" | "session.tool.failed",
+  { sessionID: string; id: string; name?: string }
+>;
+
+/** A turn began — the user's prompt was admitted and work started. */
+export type V2SessionExecutionStarted = V2Envelope<
+  "session.execution.started",
+  { sessionID: string }
+>;
+
+/** A turn ended. `interrupted` marks an aborted turn, whose numbers must not be trusted. */
+export type V2SessionExecutionSettled = V2Envelope<
+  "session.execution.succeeded" | "session.execution.failed" | "session.execution.interrupted",
+  { sessionID: string; reason?: string; error?: { message?: string } }
+>;
+
+/** Extended union the meter consumes for Tier 2 metrics. */
+export type V2ExtendedEvent =
+  | V2SessionStepStarted
+  | V2SessionToolInputStarted
+  | V2SessionToolCalled
+  | V2SessionToolSettled
+  | V2SessionExecutionStarted
+  | V2SessionExecutionSettled;
+
+/** Everything the meter subscribes to. */
+export type V2AnyMeterEvent = V2MeterEvent | V2ExtendedEvent;
+
+// ---------------------------------------------------------------- TUI extras
+
+/** Solid store tuple returned by both storage tiers. */
+export type V2StoreHandle<Value extends object> = readonly [
+  Value,
+  (mutation: (draft: Value) => void) => unknown,
+];
+
+/**
+ * Durable and ephemeral plugin state.
+ *
+ * `store` persists to disk under a cross-process lock and live-syncs to every running TUI;
+ * `memory` is synchronous and survives hot reload. v1 had neither — its TUI KV is documented
+ * as unsupported in v2 — so a v1 plugin loses all state when the TUI exits.
+ */
+export interface V2Storage {
+  readonly store: <Value extends object>(
+    key: string,
+    options: { readonly initial: Value }
+  ) => V2StoreHandle<Value>;
+  readonly memory: <Value extends object>(
+    key: string,
+    options: { readonly initial: Value }
+  ) => V2StoreHandle<Value>;
+}
+
+/** Session metadata exposed to the TUI. */
+export interface V2SessionInfo {
+  readonly id?: string;
+  readonly parentID?: string;
+  readonly title?: string;
+  readonly agent?: string;
+  readonly model?: V2ModelRef;
+}
+
+/** Read side of the TUI's synced data store. */
+export interface V2SessionData {
+  readonly get: (sessionID: string) => V2SessionInfo | undefined;
+  readonly root: (sessionID: string) => string;
+  readonly family: (sessionID: string) => string[];
+  readonly cost: (sessionID: string) => number;
+  readonly status: (sessionID: string) => "idle" | "running";
+}
+
+/** A page contributed to the TUI router. */
+export interface V2Page {
+  readonly name: string;
+  readonly render: (input: { readonly data?: Record<string, unknown> }) => unknown;
+}
+
+export interface V2Router {
+  readonly register: (page: V2Page) => () => void;
+  readonly navigate: (destination: Record<string, unknown>) => void;
+  readonly current: () => { readonly type: string; readonly sessionID?: string };
+}


### PR DESCRIPTION
Adds OpenCode v2 (`opencode2`) support alongside v1 from a single package, plus the performance work that came out of building it.

## Why this is a port, not a version bump

v2 deleted the entire `message.*` event family this plugin was built on. The mapping is:

| v1 | v2 |
|---|---|
| `message.part.delta` (field `text`) | `session.text.delta` |
| `message.part.updated` (reasoning) | `session.reasoning.delta` |
| `message.updated` (completed) | `session.step.ended` |
| `message.updated` (`info.tokens`) | `session.usage.updated` |
| `session.idle` | unchanged |

Role filtering is gone — text and reasoning deltas are assistant output by construction, so v1's message-role and part-type caches have no successor.

Two v2 loader constraints shaped the design:

- **The default export must be an object.** v2 validates it against a schema and rejects a callable with `SchemaError(Expected object at ["default"])`. v1 accepts both shapes, so the object form is the only one that works on both — v1 reads `server`/`tui`, v2 reads `setup`.
- **`@opentui/solid` cannot be imported in the service process.** It dies with `Environment variable "OPENTUI_FORCE_WCWIDTH" is already registered`, which fails the plugin load. The root bundle therefore reaches the TUI half through a runtime import, and a test asserts no static import creeps back in.

## What v2 makes possible

Measurements v1 could not make, because its events carried no timestamps and `StepStartPart` carried neither model nor agent:

- **Calibrated live rate** — each step compares streamed heuristic tokens against the provider's count and learns a per-model correction.
- **Generation vs end-to-end TPS** — tool execution is bracketed and subtracted, so a turn that waited on a shell command still reports the model's real rate.
- **Time to first token**, measured on the host clock.
- **Hidden overhead** — `session.usage.updated` is a *cumulative* session figure including auto-title and compaction; `session.step.ended` is a *per-step delta*. Their residual is spend the user never asked for. These two must never be substituted for one another.
- **Per-subagent breakdown** via `ctx.data.session.root`/`.family`, replacing v1's session-ID-comparison heuristic.
- **Durable ledger and `/tps` dashboard** through `ctx.storage.store`, which survives restarts and syncs across windows. v1's TUI KV is documented as unsupported in v2.
- **Wire-level TTFB** from the server half. Server and TUI are separate processes, so this is exposed to embedders and cannot reach the on-screen meter.

## Performance

Delta counting re-read the whole accumulated response on every chunk — O(total) per delta, O(n²) per response.

| word heuristic, 186k chars | before | after |
|---|---|---|
| v2 path | 10,223 ms | **12.2 ms** |
| v1 path (62k chars) | 1,571 ms, +11.7 MB | **10.4 ms**, no measurable churn |

Counts are asserted identical to the batch counter across three algorithms, nine corpora and six chunk sizes — including words split across a chunk boundary — plus a guard that fails if anyone reintroduces O(n²).

Live updates were also being dropped: `publish()` timestamped on the host clock while the throttle timer compared against `Date.now()`, and a timer whose guard failed was discarded without rescheduling. Over 120 deltas at a 10 ms cadence that meant **8 updates, p50 184 ms**; it is now **120 updates, p50 15.3 ms**, where the residual is the benchmark's own timer granularity.

## Compatibility

v1 behaviour is unchanged and asserted: `createTracker` without the new option behaves exactly as before, `loadConfigSync` without overrides is untouched, and the v1 suites still pass. `@opentui/solid` and `solid-js` move to optional peers because the host must supply the renderer — a nested copy gives the meter its own reactive graph and it renders once, then freezes.

## Verification

- 97 tests pass; typecheck, dead-code (`--noUnusedLocals`) and build all clean
- Every commit typechecks standalone, so the history is bisectable
- Benchmarks committed under `bench/` — `bun run bench`

**Confirmed on real hardware:** the meter renders and updates through a running turn on `opencode2` beta. The dashboard, sidebar panel and calibration are covered by tests but have not been exercised in a live TUI.

## Notes for review

- `after: "prompt.footer.status"` is deliberate. The host's own child in that slot has `flexGrow: 1` and grows further while a turn runs, so anything claimed *inside* the boundary collapses to zero width during streaming, tool calls and compaction. Claiming as a sibling keeps the meter visible.
- v2 types are hand-written structurally rather than imported: v1 and v2 types ship under one package name so both cannot be installed while this package supports both, and the v2 API is beta.
- Every optional host API is feature-detected **and** guarded — presence does not guarantee the signature matches, and an unguarded throw aborts `setup`, which the host treats as a failed plugin load with nothing in the log.
